### PR TITLE
Continued porting..

### DIFF
--- a/depends/packages/chia_bls.mk
+++ b/depends/packages/chia_bls.mk
@@ -1,0 +1,51 @@
+package=chia_bls
+$(package)_version=v20181101
+# It's actually from https://github.com/Chia-Network/bls-signatures, but we have so many patches atm that it's forked
+$(package)_download_path=https://github.com/codablock/bls-signatures/archive
+$(package)_file_name=$($(package)_version).tar.gz
+$(package)_sha256_hash=b3ec74a77a7b6795f84b05e051a0824ef8d9e05b04b2993f01040f35689aa87c
+# $(package)_dependencies=gmp
+#$(package)_patches=...TODO (when we switch back to https://github.com/Chia-Network/bls-signatures)
+
+#define $(package)_preprocess_cmds
+#  for i in $($(package)_patches); do patch -N -p1 < $($(package)_patch_dir)/$$$$i; done
+#endef
+
+define $(package)_set_vars
+  $(package)_config_opts=-DCMAKE_INSTALL_PREFIX=$($(package)_staging_dir)/$(host_prefix)
+  $(package)_config_opts+= -DCMAKE_PREFIX_PATH=$(host_prefix)
+  $(package)_config_opts+= -DSTLIB=ON -DSHLIB=OFF -DSTBIN=ON
+  $(package)_config_opts_linux=-DOPSYS=LINUX -DCMAKE_SYSTEM_NAME=Linux
+  $(package)_config_opts_darwin=-DOPSYS=MACOSX -DCMAKE_SYSTEM_NAME=Darwin
+  $(package)_config_opts_mingw32=-DOPSYS=WINDOWS -DCMAKE_SYSTEM_NAME=Windows -DCMAKE_SHARED_LIBRARY_LINK_C_FLAGS="" -DCMAKE_SHARED_LIBRARY_LINK_CXX_FLAGS=""
+  $(package)_config_opts_i686+= -DWSIZE=32
+  $(package)_config_opts_x86_64+= -DWSIZE=64
+  $(package)_config_opts_arm+= -DWSIZE=32
+  $(package)_config_opts_armv7l+= -DWSIZE=32
+  $(package)_config_opts_debug=-DDEBUG=ON -DCMAKE_BUILD_TYPE=Debug
+
+  ifneq ($(darwin_native_toolchain),)
+    $(package)_config_opts_darwin+= -DCMAKE_AR="$(host_prefix)/native/bin/$($(package)_ar)"
+    $(package)_config_opts_darwin+= -DCMAKE_RANLIB="$(host_prefix)/native/bin/$($(package)_ranlib)"
+  endif
+endef
+
+define $(package)_config_cmds
+  export CC="$($(package)_cc)" && \
+  export CXX="$($(package)_cxx)" && \
+  export CFLAGS="$($(package)_cflags) $($(package)_cppflags)" && \
+  export CXXFLAGS="$($(package)_cxxflags) $($(package)_cppflags)" && \
+  export LDFLAGS="$($(package)_ldflags)" && \
+  mkdir -p build && cd build && \
+  cmake ../ $($(package)_config_opts)
+endef
+
+define $(package)_build_cmds
+  cd build && \
+  $(MAKE) $($(package)_build_opts)
+endef
+
+define $(package)_stage_cmds
+  cd build && \
+  $(MAKE) install
+endef

--- a/depends/packages/gmp.mk
+++ b/depends/packages/gmp.mk
@@ -1,0 +1,22 @@
+package=gmp
+$(package)_version=6.1.2
+$(package)_download_path=https://gmplib.org/download/gmp
+$(package)_file_name=gmp-$($(package)_version).tar.bz2
+$(package)_sha256_hash=5275bb04f4863a13516b2f39392ac5e272f5e1bb8057b18aec1c9b79d73d8fb2
+
+define $(package)_set_vars
+$(package)_config_opts+=--enable-cxx --enable-fat --with-pic --disable-shared
+$(package)_cflags_armv7l_linux+=-march=armv7-a
+endef
+
+define $(package)_config_cmds
+  $($(package)_autoconf)
+endef
+
+define $(package)_build_cmds
+  $(MAKE)
+endef
+
+define $(package)_stage_cmds
+  $(MAKE) DESTDIR=$($(package)_staging_dir) install
+endef

--- a/depends/packages/packages.mk
+++ b/depends/packages/packages.mk
@@ -1,4 +1,4 @@
-packages:=boost libevent
+packages:=boost libevent gmp chia_bls
 
 qt_packages = zlib
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -197,6 +197,8 @@ BITCOIN_CORE_H = \
   script/standard.h \
   shutdown.h \
   streams.h \
+  support/allocators/mt_pooled_secure.h \
+  support/allocators/pooled_secure.h \
   support/allocators/secure.h \
   support/allocators/zeroafterfree.h \
   support/cleanse.h \

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -313,16 +313,6 @@ public:
         consensus.vDeployments[Consensus::DEPLOYMENT_TESTDUMMY].nStartTime = 1199145601; // January 1, 2008
         consensus.vDeployments[Consensus::DEPLOYMENT_TESTDUMMY].nTimeout = 1230767999;   // December 31, 2008
 
-        // Deployment of BIP68, BIP112, and BIP113.
-        consensus.vDeployments[Consensus::DEPLOYMENT_CSV].bit = 0;
-        consensus.vDeployments[Consensus::DEPLOYMENT_CSV].nStartTime = 1456790400; // March 1st, 2016
-        consensus.vDeployments[Consensus::DEPLOYMENT_CSV].nTimeout = 1493596800;   // May 1st, 2017
-
-        // Deployment of SegWit (BIP141, BIP143, and BIP147)
-        consensus.vDeployments[Consensus::DEPLOYMENT_SEGWIT].bit = 1;
-        consensus.vDeployments[Consensus::DEPLOYMENT_SEGWIT].nStartTime = 1462060800; // May 1st 2016
-        consensus.vDeployments[Consensus::DEPLOYMENT_SEGWIT].nTimeout = 1493596800;   // May 1st 2017
-
         // The best chain should have at least this much work.
         consensus.nMinimumChainWork = uint256S("0x00");
 
@@ -433,12 +423,6 @@ public:
         consensus.vDeployments[Consensus::DEPLOYMENT_TESTDUMMY].bit = 28;
         consensus.vDeployments[Consensus::DEPLOYMENT_TESTDUMMY].nStartTime = 0;
         consensus.vDeployments[Consensus::DEPLOYMENT_TESTDUMMY].nTimeout = Consensus::BIP9Deployment::NO_TIMEOUT;
-        consensus.vDeployments[Consensus::DEPLOYMENT_CSV].bit = 0;
-        consensus.vDeployments[Consensus::DEPLOYMENT_CSV].nStartTime = 0;
-        consensus.vDeployments[Consensus::DEPLOYMENT_CSV].nTimeout = Consensus::BIP9Deployment::NO_TIMEOUT;
-        consensus.vDeployments[Consensus::DEPLOYMENT_SEGWIT].bit = 1;
-        consensus.vDeployments[Consensus::DEPLOYMENT_SEGWIT].nStartTime = Consensus::BIP9Deployment::ALWAYS_ACTIVE;
-        consensus.vDeployments[Consensus::DEPLOYMENT_SEGWIT].nTimeout = Consensus::BIP9Deployment::NO_TIMEOUT;
 
         // The best chain should have at least this much work.
         consensus.nMinimumChainWork = uint256S("0x00");

--- a/src/coins.h
+++ b/src/coins.h
@@ -71,7 +71,7 @@ public:
         assert(!IsSpent());
         uint32_t code = nHeight * 2 + fCoinBase;
         ::Serialize(s, VARINT(code));
-        ::Serialize(s, REF(out));
+        ::Serialize(s, CTxOutCompressor(REF(out)));
         // proof-of-stake flag
         unsigned int nFlag = fCoinStake ? 1 : 0;
         ::Serialize(s, VARINT(nFlag));
@@ -83,7 +83,7 @@ public:
         ::Unserialize(s, VARINT(code));
         nHeight = code >> 1;
         fCoinBase = code & 1;
-        ::Unserialize(s, out);
+        ::Unserialize(s, CTxOutCompressor(out));
         // proof-of-stake flag
         unsigned int nFlag = 0;
         ::Unserialize(s, VARINT(nFlag));
@@ -121,7 +121,7 @@ public:
      *
      * @see https://gcc.gnu.org/onlinedocs/gcc-9.2.0/libstdc++/manual/manual/unordered_associative.html
      */
-    size_t operator()(const COutPoint& id) const noexcept {
+    size_t operator()(const COutPoint& id) const {
         return SipHashUint256Extra(k0, k1, id.hash, id.n);
     }
 };

--- a/src/compressor.cpp
+++ b/src/compressor.cpp
@@ -5,6 +5,7 @@
 
 #include <compressor.h>
 
+#include <hash.h>
 #include <pubkey.h>
 #include <script/standard.h>
 

--- a/src/compressor.h
+++ b/src/compressor.h
@@ -11,6 +11,10 @@
 #include <serialize.h>
 #include <span.h>
 
+class CKeyID;
+class CPubKey;
+class CScriptID;
+
 bool CompressScript(const CScript& script, std::vector<unsigned char> &out);
 unsigned int GetSpecialScriptSize(unsigned int nSize);
 bool DecompressScript(CScript& script, unsigned int nSize, const std::vector<unsigned char> &out);
@@ -39,8 +43,9 @@ uint64_t DecompressAmount(uint64_t nAmount);
  *  Other scripts up to 121 bytes require 1 byte + script length. Above
  *  that, scripts up to 16505 bytes require 2 bytes + script length.
  */
-struct ScriptCompression
+class CScriptCompressor
 {
+private:
     /**
      * make this static for now (there are only 6 special scripts defined)
      * this can potentially be extended together with a new nVersion for
@@ -49,8 +54,12 @@ struct ScriptCompression
      */
     static const unsigned int nSpecialScripts = 6;
 
+    CScript &script;
+public:
+    explicit CScriptCompressor(CScript &scriptIn) : script(scriptIn) { }
+
     template<typename Stream>
-    void Ser(Stream &s, const CScript& script) {
+    void Serialize(Stream &s) const {
         std::vector<unsigned char> compr;
         if (CompressScript(script, compr)) {
             s << MakeSpan(compr);
@@ -62,7 +71,7 @@ struct ScriptCompression
     }
 
     template<typename Stream>
-    void Unser(Stream &s, CScript& script) {
+    void Unserialize(Stream &s) {
         unsigned int nSize = 0;
         s >> VARINT(nSize);
         if (nSize < nSpecialScripts) {
@@ -83,24 +92,30 @@ struct ScriptCompression
     }
 };
 
-struct AmountCompression
-{
-    template<typename Stream, typename I> void Ser(Stream& s, I val)
-    {
-        s << VARINT(CompressAmount(val));
-    }
-    template<typename Stream, typename I> void Unser(Stream& s, I& val)
-    {
-        uint64_t v;
-        s >> VARINT(v);
-        val = DecompressAmount(v);
-    }
-};
-
 /** wrapper for CTxOut that provides a more compact serialization */
-struct TxOutCompression
+class CTxOutCompressor
 {
-    FORMATTER_METHODS(CTxOut, obj) { READWRITE(Using<AmountCompression>(obj.nValue), Using<ScriptCompression>(obj.scriptPubKey)); }
+private:
+    CTxOut &txout;
+
+public:
+    explicit CTxOutCompressor(CTxOut &txoutIn) : txout(txoutIn) { }
+
+    ADD_SERIALIZE_METHODS;
+
+    template <typename Stream, typename Operation>
+    inline void SerializationOp(Stream& s, Operation ser_action) {
+        if (!ser_action.ForRead()) {
+            uint64_t nVal = CompressAmount(txout.nValue);
+            READWRITE(VARINT(nVal));
+        } else {
+            uint64_t nVal = 0;
+            READWRITE(VARINT(nVal));
+            txout.nValue = DecompressAmount(nVal);
+        }
+        CScriptCompressor cscript(REF(txout.scriptPubKey));
+        READWRITE(cscript);
+    }
 };
 
 #endif // BITCOIN_COMPRESSOR_H

--- a/src/consensus/tx_check.cpp
+++ b/src/consensus/tx_check.cpp
@@ -22,7 +22,7 @@ bool CheckTransaction(const CTransaction& tx, TxValidationState& state)
     if (::GetSerializeSize(tx, PROTOCOL_VERSION | SERIALIZE_TRANSACTION_NO_WITNESS) * WITNESS_SCALE_FACTOR > MAX_BLOCK_WEIGHT)
         return state.Invalid(TxValidationResult::TX_CONSENSUS, "bad-txns-oversize");
     if (tx.vExtraPayload.size() > MAX_TX_EXTRA_PAYLOAD)
-        return state.Invalid(ValidationInvalidReason::CONSENSUS, false, REJECT_INVALID, "bad-txns-payload-oversize");
+        return state.Invalid(TxValidationResult::TX_CONSENSUS, "bad-txns-payload-oversize");
 
     // check transaction types
     if (tx.nVersion >= 2 &&
@@ -33,9 +33,9 @@ bool CheckTransaction(const CTransaction& tx, TxValidationState& state)
         tx.nType != TRANSACTION_PROVIDER_UPDATE_REVOKE &&
         tx.nType != TRANSACTION_QUORUM_COMMITMENT &&
         tx.nType != TRANSACTION_STAKE)
-        return state.Invalid(ValidationInvalidReason::CONSENSUS, false, REJECT_INVALID, "bad-txns-type");
+        return state.Invalid(TxValidationResult::TX_CONSENSUS, "bad-txns-type");
     if (tx.IsCoinBase() && tx.nVersion >= 2 && tx.nType != TRANSACTION_COINBASE)
-        return state.Invalid(ValidationInvalidReason::CONSENSUS, false, REJECT_INVALID, "bad-txns-cb-type");
+        return state.Invalid(TxValidationResult::TX_CONSENSUS, "bad-txns-cb-type");
 
     // Check for negative or overflow output values (see CVE-2010-5139)
     CAmount nValueOut = 0;

--- a/src/dbwrapper.h
+++ b/src/dbwrapper.h
@@ -11,6 +11,9 @@
 #include <streams.h>
 #include <util/system.h>
 #include <util/strencodings.h>
+#include <version.h>
+
+#include <typeindex>
 
 #include <leveldb/db.h>
 #include <leveldb/write_batch.h>

--- a/src/llmq/quorums_blockprocessor.h
+++ b/src/llmq/quorums_blockprocessor.h
@@ -40,7 +40,7 @@ public:
 
     void ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStream& vRecv, CConnman* connman);
 
-    bool ProcessBlock(const CBlock& block, const CBlockIndex* pindex, BlockValidationState& state);
+    bool ProcessBlock(const CBlock& block, const CBlockIndex* pindex, TxValidationState& state);
     bool UndoBlock(const CBlock& block, const CBlockIndex* pindex);
 
     void AddMinableCommitment(const CFinalCommitment& fqc);

--- a/src/llmq/quorums_commitment.cpp
+++ b/src/llmq/quorums_commitment.cpp
@@ -157,47 +157,47 @@ void CFinalCommitmentTxPayload::ToJson(UniValue& obj) const
     obj.pushKV("commitment", qcObj);
 }
 
-bool CheckLLMQCommitment(const CTransaction& tx, const CBlockIndex* pindexPrev, BlockValidationState& state)
+bool CheckLLMQCommitment(const CTransaction& tx, const CBlockIndex* pindexPrev, TxValidationState& state)
 {
     CFinalCommitmentTxPayload qcTx;
     if (!GetTxPayload(tx, qcTx)) {
-        return state.Invalid(BlockValidationResult::BLOCK_CONSENSUS, "bad-qc-payload");
+        return state.Invalid(TxValidationResult::TX_CONSENSUS, "bad-qc-payload");
     }
 
     if (qcTx.nVersion == 0 || qcTx.nVersion > CFinalCommitmentTxPayload::CURRENT_VERSION) {
-        return state.Invalid(BlockValidationResult::BLOCK_CONSENSUS, "bad-qc-version");
+        return state.Invalid(TxValidationResult::TX_CONSENSUS, "bad-qc-version");
     }
 
     if (qcTx.nHeight != pindexPrev->nHeight + 1) {
-        return state.Invalid(BlockValidationResult::BLOCK_CONSENSUS, "bad-qc-height");
+        return state.Invalid(TxValidationResult::TX_CONSENSUS, "bad-qc-height");
     }
 
     if (!::BlockIndex().count(qcTx.commitment.quorumHash)) {
-        return state.Invalid(BlockValidationResult::BLOCK_CONSENSUS, "bad-qc-quorum-hash");
+        return state.Invalid(TxValidationResult::TX_CONSENSUS, "bad-qc-quorum-hash");
     }
 
     const CBlockIndex* pindexQuorum = ::BlockIndex()[qcTx.commitment.quorumHash];
 
     if (pindexQuorum != pindexPrev->GetAncestor(pindexQuorum->nHeight)) {
         // not part of active chain
-        return state.Invalid(BlockValidationResult::BLOCK_CONSENSUS, "bad-qc-quorum-hash");
+        return state.Invalid(TxValidationResult::TX_CONSENSUS, "bad-qc-quorum-hash");
     }
 
     if (!Params().GetConsensus().llmqs.count((Consensus::LLMQType)qcTx.commitment.llmqType)) {
-        return state.Invalid(BlockValidationResult::BLOCK_CONSENSUS, "bad-qc-type");
+        return state.Invalid(TxValidationResult::TX_CONSENSUS, "bad-qc-type");
     }
     const auto& params = Params().GetConsensus().llmqs.at((Consensus::LLMQType)qcTx.commitment.llmqType);
 
     if (qcTx.commitment.IsNull()) {
         if (!qcTx.commitment.VerifyNull()) {
-            return state.Invalid(BlockValidationResult::BLOCK_CONSENSUS, "bad-qc-invalid-null");
+            return state.Invalid(TxValidationResult::TX_CONSENSUS, "bad-qc-invalid-null");
         }
         return true;
     }
 
     auto members = CLLMQUtils::GetAllQuorumMembers(params.type, pindexQuorum);
     if (!qcTx.commitment.Verify(members, false)) {
-        return state.Invalid(BlockValidationResult::BLOCK_CONSENSUS, "bad-qc-invalid");
+        return state.Invalid(TxValidationResult::TX_CONSENSUS, "bad-qc-invalid");
     }
 
     return true;

--- a/src/llmq/quorums_commitment.h
+++ b/src/llmq/quorums_commitment.h
@@ -113,7 +113,7 @@ public:
     void ToJson(UniValue& obj) const;
 };
 
-bool CheckLLMQCommitment(const CTransaction& tx, const CBlockIndex* pindexPrev, BlockValidationState& state);
+bool CheckLLMQCommitment(const CTransaction& tx, const CBlockIndex* pindexPrev, TxValidationState& state);
 
 }
 

--- a/src/masternodes/sync.cpp
+++ b/src/masternodes/sync.cpp
@@ -178,7 +178,7 @@ void CMasternodeSync::ProcessTick(CConnman& connman)
 
         // NORMAL NETWORK MODE - TESTNET/MAINNET
         {
-            if ((pnode->fWhitelisted || pnode->m_manual_connection) && !netfulfilledman.HasFulfilledRequest(pnode->addr, strAllow)) {
+            if ((pnode->m_legacyWhitelisted || pnode->m_manual_connection) && !netfulfilledman.HasFulfilledRequest(pnode->addr, strAllow)) {
                 netfulfilledman.RemoveAllFulfilledRequests(pnode->addr);
                 netfulfilledman.AddFulfilledRequest(pnode->addr, strAllow);
                 LogPrintf("CMasternodeSync::ProcessTick -- skipping mnsync restrictions for peer=%d\n", pnode->GetId());

--- a/src/rpc/special.cpp
+++ b/src/rpc/special.cpp
@@ -282,7 +282,7 @@ static std::string SignAndSendSpecialTx(const CMutableTransaction& tx)
         LOCK(cs_main);
         const CTransaction& ctx = CTransaction(tx);
 
-        CValidationState state;
+        TxValidationState state;
         if (!CheckSpecialTx(ctx, ChainActive().Tip(), state)) {
             throw std::runtime_error(state.ToString());
         }

--- a/src/special/cbtx.h
+++ b/src/special/cbtx.h
@@ -44,9 +44,9 @@ public:
     void ToJson(UniValue& obj) const;
 };
 
-bool CheckCbTx(const CTransaction& tx, const CBlockIndex* pindexPrev, BlockValidationState& state);
-bool CheckCbTxMerkleRoots(const CBlock& block, const CBlockIndex* pindex, BlockValidationState& state);
-bool CalcCbTxMerkleRootMNList(const CBlock& block, const CBlockIndex* pindexPrev, uint256& merkleRootRet, BlockValidationState& state);
-bool CalcCbTxMerkleRootQuorums(const CBlock& block, const CBlockIndex* pindexPrev, uint256& merkleRootRet, BlockValidationState& state);
+bool CheckCbTx(const CTransaction& tx, const CBlockIndex* pindexPrev, TxValidationState& state);
+bool CheckCbTxMerkleRoots(const CBlock& block, const CBlockIndex* pindex, TxValidationState& state);
+bool CalcCbTxMerkleRootMNList(const CBlock& block, const CBlockIndex* pindexPrev, uint256& merkleRootRet, TxValidationState& state);
+bool CalcCbTxMerkleRootQuorums(const CBlock& block, const CBlockIndex* pindexPrev, uint256& merkleRootRet, TxValidationState& state);
 
 #endif //BITGREEN_SPECIAL_CBTX_H

--- a/src/special/deterministicmns.h
+++ b/src/special/deterministicmns.h
@@ -21,7 +21,7 @@
 
 class CBlock;
 class CBlockIndex;
-class BlockValidationState;
+class TxValidationState;
 
 namespace llmq
 {
@@ -641,13 +641,13 @@ private:
 public:
     CDeterministicMNManager(CSpecialDB& _specialDb);
 
-    bool ProcessBlock(const CBlock& block, const CBlockIndex* pindex, BlockValidationState& state, bool fJustCheck);
+    bool ProcessBlock(const CBlock& block, const CBlockIndex* pindex, TxValidationState& state, bool fJustCheck);
     bool UndoBlock(const CBlock& block, const CBlockIndex* pindex);
 
     void UpdatedBlockTip(const CBlockIndex* pindex);
 
     // the returned list will not contain the correct block hash (we can't know it yet as the coinbase TX is not updated yet)
-    bool BuildNewListFromBlock(const CBlock& block, const CBlockIndex* pindexPrev, BlockValidationState& state, CDeterministicMNList& mnListRet, bool debugLogs);
+    bool BuildNewListFromBlock(const CBlock& block, const CBlockIndex* pindexPrev, TxValidationState& state, CDeterministicMNList& mnListRet, bool debugLogs);
     void HandleQuorumCommitment(llmq::CFinalCommitment& qc, const CBlockIndex* pindexQuorum, CDeterministicMNList& mnList, bool debugLogs);
     void DecreasePoSePenalties(CDeterministicMNList& mnList);
 

--- a/src/special/specialtx.cpp
+++ b/src/special/specialtx.cpp
@@ -19,7 +19,7 @@
 #include <llmq/quorums_blockprocessor.h>
 
 
-bool CheckSpecialTx(const CTransaction& tx, const CBlockIndex* pindexPrev, BlockValidationState& state)
+bool CheckSpecialTx(const CTransaction& tx, const CBlockIndex* pindexPrev, TxValidationState& state)
 {
     if (tx.nVersion < 2 || tx.nType == TRANSACTION_NORMAL || tx.nType == TRANSACTION_STAKE)
         return true;
@@ -39,10 +39,10 @@ bool CheckSpecialTx(const CTransaction& tx, const CBlockIndex* pindexPrev, Block
         return llmq::CheckLLMQCommitment(tx, pindexPrev, state);
     }
 
-    return state.Invalid(ValidationInvalidReason::CONSENSUS, false, REJECT_INVALID, "bad-tx-type-check");
+    return state.Invalid(TxValidationResult::TX_CONSENSUS, "bad-tx-type-check");
 }
 
-bool ProcessSpecialTx(const CTransaction& tx, const CBlockIndex* pindex, BlockValidationState& state)
+bool ProcessSpecialTx(const CTransaction& tx, const CBlockIndex* pindex, TxValidationState& state)
 {
     if (tx.nVersion < 2 || tx.nType == TRANSACTION_NORMAL || tx.nType == TRANSACTION_STAKE)
         return true;
@@ -59,7 +59,7 @@ bool ProcessSpecialTx(const CTransaction& tx, const CBlockIndex* pindex, BlockVa
         return true; // handled per block
     }
 
-    return state.Invalid(ValidationInvalidReason::CONSENSUS, false, REJECT_INVALID, "bad-tx-type-proc");
+    return state.Invalid(TxValidationResult::TX_CONSENSUS, "bad-tx-type-proc");
 }
 
 bool UndoSpecialTx(const CTransaction& tx, const CBlockIndex* pindex)
@@ -82,7 +82,7 @@ bool UndoSpecialTx(const CTransaction& tx, const CBlockIndex* pindex)
     return false;
 }
 
-bool ProcessSpecialTxsInBlock(const CBlock& block, const CBlockIndex* pindex, BlockValidationState& state, bool fJustCheck, bool fCheckCbTxMerleRoots)
+bool ProcessSpecialTxsInBlock(const CBlock& block, const CBlockIndex* pindex, TxValidationState& state, bool fJustCheck, bool fCheckCbTxMerleRoots)
 {
     static int64_t nTimeLoop = 0;
     static int64_t nTimeQuorum = 0;

--- a/src/special/specialtx.h
+++ b/src/special/specialtx.h
@@ -15,7 +15,7 @@ class CBlockIndex;
 class TxValidationState;
 
 bool CheckSpecialTx(const CTransaction& tx, const CBlockIndex* pindexPrev, TxValidationState& state);
-bool ProcessSpecialTxsInBlock(const CBlock& block, const CBlockIndex* pindex, BlockValidationState& state, bool fJustCheck, bool fCheckCbTxMerleRoots);
+bool ProcessSpecialTxsInBlock(const CBlock& block, const CBlockIndex* pindex, TxValidationState& state, bool fJustCheck, bool fCheckCbTxMerleRoots);
 bool UndoSpecialTxsInBlock(const CBlock& block, const CBlockIndex* pindex);
 
 template <typename T>

--- a/src/special/util.cpp
+++ b/src/special/util.cpp
@@ -10,7 +10,7 @@
 bool GetUTXOCoin(const COutPoint& outpoint, Coin& coin)
 {
     LOCK(cs_main);
-    if (!pcoinsTip->GetCoin(outpoint, coin))
+    if (!::ChainstateActive().CoinsTip().GetCoin(outpoint, coin))
         return false;
     if (coin.IsSpent())
         return false;

--- a/src/spork.cpp
+++ b/src/spork.cpp
@@ -204,7 +204,7 @@ void CSporkManager::ExecuteSpork(int nSporkID, int nValue)
 
         LogPrint(BCLog::SPORK, "CSporkManager::ExecuteSpork -- Reconsider Last %d Blocks\n", nValue);
 
-        ReprocessBlocks(nValue);
+        //ReprocessBlocks(nValue);
         nTimeExecuted = GetTime();
     }
 }

--- a/src/support/allocators/mt_pooled_secure.h
+++ b/src/support/allocators/mt_pooled_secure.h
@@ -1,0 +1,86 @@
+// Copyright (c) 2014-2018 The Dash Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITGREEN_SUPPORT_ALLOCATORS_MT_POOLED_SECURE_H
+#define BITGREEN_SUPPORT_ALLOCATORS_MT_POOLED_SECURE_H
+
+#include <support/allocators/pooled_secure.h>
+#include <util/memory.h>
+
+#include <thread>
+#include <mutex>
+
+//
+// Manages a pool of pools to balance allocation between those when multiple threads are involved
+// This allocator is fully thread safe
+//
+template <typename T>
+struct mt_pooled_secure_allocator : public std::allocator<T> {
+    // MSVC8 default copy constructor is broken
+    typedef std::allocator<T> base;
+    typedef typename base::size_type size_type;
+    typedef typename base::difference_type difference_type;
+    typedef typename base::pointer pointer;
+    typedef typename base::const_pointer const_pointer;
+    typedef typename base::reference reference;
+    typedef typename base::const_reference const_reference;
+    typedef typename base::value_type value_type;
+    mt_pooled_secure_allocator(size_type nrequested_size = 32,
+                               size_type nnext_size = 32,
+                               size_type nmax_size = 0) throw()
+    {
+        // we add enough bytes to the requested size so that we can store the bucket as well
+        nrequested_size += sizeof(size_t);
+
+        size_t pools_count = std::thread::hardware_concurrency();
+        pools.resize(pools_count);
+        for (size_t i = 0; i < pools_count; i++) {
+            pools[i] = MakeUnique<internal_pool>(nrequested_size, nnext_size, nmax_size);
+        }
+    }
+    ~mt_pooled_secure_allocator() throw() {}
+
+    T* allocate(std::size_t n, const void* hint = 0)
+    {
+        size_t bucket = get_bucket();
+        std::lock_guard<std::mutex> lock(pools[bucket]->mutex);
+        uint8_t* ptr = pools[bucket]->allocate(n * sizeof(T) + sizeof(size_t));
+        *(size_t*)ptr = bucket;
+        return static_cast<T*>(ptr + sizeof(size_t));
+    }
+
+    void deallocate(T* p, std::size_t n)
+    {
+        if (!p) {
+            return;
+        }
+        uint8_t* ptr = (uint8_t*)p - sizeof(size_t);
+        size_t bucket = *(size_t*)ptr;
+        std::lock_guard<std::mutex> lock(pools[bucket]->mutex);
+        pools[bucket]->deallocate(ptr, n * sizeof(T));
+    }
+
+private:
+    size_t get_bucket()
+    {
+        auto tid = std::this_thread::get_id();
+        size_t x = std::hash<std::thread::id>{}(std::this_thread::get_id());
+        return x % pools.size();
+    }
+
+    struct internal_pool : pooled_secure_allocator<uint8_t> {
+        internal_pool(size_type nrequested_size,
+                      size_type nnext_size,
+                      size_type nmax_size) :
+                      pooled_secure_allocator(nrequested_size, nnext_size, nmax_size)
+        {
+        }
+        std::mutex mutex;
+    };
+
+private:
+    std::vector<std::unique_ptr<internal_pool>> pools;
+};
+
+#endif // BITGREEN_SUPPORT_ALLOCATORS_MT_POOLED_SECURE_H

--- a/src/support/allocators/pooled_secure.h
+++ b/src/support/allocators/pooled_secure.h
@@ -1,0 +1,73 @@
+// Copyright (c) 2014-2018 The Dash Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITGREEN_SUPPORT_ALLOCATORS_POOLED_SECURE_H
+#define BITGREEN_SUPPORT_ALLOCATORS_POOLED_SECURE_H
+
+#include <support/lockedpool.h>
+#include <support/cleanse.h>
+
+#include <string>
+#include <vector>
+
+#include <boost/pool/pool_alloc.hpp>
+
+//
+// Allocator that allocates memory in chunks from a pool, which in turn allocates larger chunks from secure memory
+// Memory is cleaned when freed as well. This allocator is NOT thread safe
+//
+template <typename T>
+struct pooled_secure_allocator : public std::allocator<T> {
+    // MSVC8 default copy constructor is broken
+    typedef std::allocator<T> base;
+    typedef typename base::size_type size_type;
+    typedef typename base::difference_type difference_type;
+    typedef typename base::pointer pointer;
+    typedef typename base::const_pointer const_pointer;
+    typedef typename base::reference reference;
+    typedef typename base::const_reference const_reference;
+    typedef typename base::value_type value_type;
+    pooled_secure_allocator(const size_type nrequested_size = 32,
+                            const size_type nnext_size = 32,
+                            const size_type nmax_size = 0) throw() :
+                            pool(nrequested_size, nnext_size, nmax_size){}
+    ~pooled_secure_allocator() throw() {}
+
+    T* allocate(std::size_t n, const void* hint = 0)
+    {
+        size_t chunks = (n * sizeof(T) + pool.get_requested_size() - 1) / pool.get_requested_size();
+        return static_cast<T*>(pool.ordered_malloc(chunks));
+    }
+
+    void deallocate(T* p, std::size_t n)
+    {
+        if (!p) {
+            return;
+        }
+
+        size_t chunks = (n * sizeof(T) + pool.get_requested_size() - 1) / pool.get_requested_size();
+        memory_cleanse(p, chunks * pool.get_requested_size());
+        pool.ordered_free(p, chunks);
+    }
+
+public:
+    struct internal_secure_allocator {
+        typedef std::size_t size_type;
+        typedef std::ptrdiff_t difference_type;
+
+        static char* malloc(const size_type bytes)
+        {
+            return static_cast<char*>(LockedPoolManager::Instance().alloc(bytes));
+        }
+
+        static void free(char* const block)
+        {
+            LockedPoolManager::Instance().free(block);
+        }
+    };
+private:
+    boost::pool<internal_secure_allocator> pool;
+};
+
+#endif // BITGREEN_SUPPORT_ALLOCATORS_POOLED_SECURE_H

--- a/src/uint256.cpp
+++ b/src/uint256.cpp
@@ -7,6 +7,7 @@
 
 #include <util/strencodings.h>
 
+#include <stdio.h>
 #include <string.h>
 
 template <unsigned int BITS>

--- a/src/uint256.h
+++ b/src/uint256.h
@@ -8,9 +8,12 @@
 
 #include <assert.h>
 #include <cstring>
+#include <stdexcept>
 #include <stdint.h>
 #include <string>
 #include <vector>
+
+#include <crypto/common.h>
 
 /** Template base class for fixed-sized opaque blobs. */
 template<unsigned int BITS>
@@ -121,6 +124,16 @@ class uint256 : public base_blob<256> {
 public:
     uint256() {}
     explicit uint256(const std::vector<unsigned char>& vch) : base_blob<256>(vch) {}
+
+    /** A cheap hash function that just returns 64 bits from the result, it can be
+     * used when the contents are considered uniformly random. It is not appropriate
+     * when the value can easily be influenced from outside as e.g. a network adversary could
+     * provide values to trigger worst-case behavior.
+     */
+    uint64_t GetCheapHash() const
+    {
+        return ReadLE64(data);
+    }
 };
 
 /* uint256 from const char *.
@@ -142,6 +155,17 @@ inline uint256 uint256S(const std::string& str)
     uint256 rv;
     rv.SetHex(str);
     return rv;
+}
+
+namespace std {
+    template <>
+    struct hash<uint256>
+    {
+        std::size_t operator()(const uint256& k) const
+        {
+            return (std::size_t)k.GetCheapHash();
+        }
+    };
 }
 
 uint256& UINT256_ONE();

--- a/src/undo.h
+++ b/src/undo.h
@@ -29,7 +29,7 @@ struct TxInUndoFormatter
             // Required to maintain compatibility with older undo format.
             ::Serialize(s, (unsigned char)0);
         }
-        ::Serialize(s, Using<TxOutCompression>(txout.out));
+        ::Serialize(s, CTxOutCompressor(REF(txout.out)));
     }
 
     template<typename Stream>
@@ -45,7 +45,7 @@ struct TxInUndoFormatter
             unsigned int nVersionDummy;
             ::Unserialize(s, VARINT(nVersionDummy));
         }
-        ::Unserialize(s, Using<TxOutCompression>(txout.out));
+        ::Unserialize(s, CTxOutCompressor(REF(txout.out)));
     }
 };
 

--- a/src/unordered_lru_cache.h
+++ b/src/unordered_lru_cache.h
@@ -1,10 +1,9 @@
-// Copyright (c) 2019 The Dash Core developers
-// Copyright (c) 2019 The BitGreen Core developers
+// Copyright (c) 2019-2020 The Dash Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#ifndef BITGREEN_UNORDERED_LRU_CACHE_H
-#define BITGREEN_UNORDERED_LRU_CACHE_H
+#ifndef DASH_UNORDERED_LRU_CACHE_H
+#define DASH_UNORDERED_LRU_CACHE_H
 
 #include <unordered_map>
 
@@ -20,7 +19,7 @@ private:
     int64_t accessCounter{0};
 
 public:
-    unordered_lru_cache(size_t _maxSize = MaxSize, size_t _truncateThreshold = TruncateThreshold) :
+    explicit unordered_lru_cache(size_t _maxSize = MaxSize, size_t _truncateThreshold = TruncateThreshold) :
         maxSize(_maxSize),
         truncateThreshold(_truncateThreshold == 0 ? _maxSize * 2 : _truncateThreshold)
     {
@@ -108,4 +107,4 @@ private:
     }
 };
 
-#endif // BITGREEN_UNORDERED_LRU_CACHE_H
+#endif // DASH_UNORDERED_LRU_CACHE_H

--- a/src/validation.h
+++ b/src/validation.h
@@ -367,10 +367,6 @@ bool ReadBlockFromDisk(CBlock& block, const CBlockIndex* pindex, const Consensus
 bool ReadRawBlockFromDisk(std::vector<uint8_t>& block, const FlatFilePos& pos, const CMessageHeader::MessageStartChars& message_start);
 bool ReadRawBlockFromDisk(std::vector<uint8_t>& block, const CBlockIndex* pindex, const CMessageHeader::MessageStartChars& message_start);
 
-/** Reprocess a number of blocks to try and get on the correct chain again **/
-bool DisconnectBlocks(int blocks);
-void ReprocessBlocks(int nBlocks);
-
 bool UndoReadFromDisk(CBlockUndo& blockundo, const CBlockIndex* pindex);
 
 /** Functions for validating blocks and updating the block tree */

--- a/src/validationinterface.h
+++ b/src/validationinterface.h
@@ -220,14 +220,14 @@ public:
     void NotifyChainLock(const CBlockIndex*);
     void NotifyGovernanceObject(const CGovernanceObject&);
     void NotifyGovernanceVote(const CGovernanceVote&);
-    void NotifyHeaderTip(const CBlockIndex *, bool fInitialDownload);
-    void NotifyInstantSendDoubleSpendAttempt(const CTransaction &currentTx, const CTransaction &previousTx);
+    void NotifyHeaderTip(const CBlockIndex *, bool);
+    void NotifyInstantSendDoubleSpendAttempt(const CTransaction &, const CTransaction &);
     void NotifyMasternodeListChanged(bool, const CDeterministicMNList&, const CDeterministicMNListDiff&);
-    void NotifyTransactionLock(const CTransaction &tx);
-    void SyncTransaction(const CTransaction &tx, const CBlockIndex *pindex, int posInBlock);
+    void NotifyTransactionLock(const CTransaction&);
+    void SyncTransaction(const CTransaction&, const CBlockIndex *, int);
     void TransactionAddedToMempool(const CTransactionRef &);
     void TransactionRemovedFromMempool(const CTransactionRef &);
-    void UpdatedBlockTip(const CBlockIndex *, const CBlockIndex *, bool fInitialDownload);
+    void UpdatedBlockTip(const CBlockIndex *, const CBlockIndex *, bool);
 };
 
 CMainSignals& GetMainSignals();

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -872,7 +872,7 @@ public:
     /**
      * populate vCoins with vector of available COutputs.
      */
-    void AvailableCoins(interfaces::Chain::Lock& locked_chain, std::vector<COutput>& vCoins, bool fOnlySafe = true, const CCoinControl* coinControl = nullptr, const CAmount& nMinimumAmount = 1, const CAmount& nMaximumAmount = MAX_MONEY, const CAmount& nMinimumSumAmount = MAX_MONEY, const uint64_t nMaximumCount = 0) const EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
+    void AvailableCoins(interfaces::Chain::Lock& locked_chain, std::vector<COutput>& vCoins, bool fOnlySafe=true, const CCoinControl *coinControl = nullptr, const CAmount& nMinimumAmount = 1, const CAmount& nMaximumAmount = MAX_MONEY, const CAmount& nMinimumSumAmount = MAX_MONEY, const uint64_t nMaximumCount = 0, const int nMinDepth = 0, const int nMaxDepth = 9999999, AvailableCoinsType nCoinType = ALL_COINS, bool fUseInstantSend = false) const EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
 
     /**
      * Return list of available coins and locked coins grouped by non-change output address.
@@ -923,6 +923,8 @@ public:
     void UpgradeKeyMetadata() EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
 
     bool LoadMinVersion(int nVersion) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet) { AssertLockHeld(cs_wallet); nWalletVersion = nVersion; nWalletMaxVersion = std::max(nWalletMaxVersion, nVersion); return true; }
+
+    bool GetKey(const CKeyID &address, CKey& keyOut) const;
 
     /**
      * Adds a destination data tuple to the store, and saves it to disk
@@ -1128,6 +1130,8 @@ public:
 
     bool DelAddressBook(const CTxDestination& address);
 
+    bool UpdatedTransaction(const uint256 &hashTx);
+
     unsigned int GetKeyPoolSize() const EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
 
     //! signify that a particular wallet feature is now used. this may change nWalletVersion and nWalletMaxVersion if those are lower
@@ -1207,6 +1211,7 @@ public:
      * Gives the wallet a chance to register repetitive tasks and complete post-init tasks
      */
     void postInitProcess();
+    bool GetBudgetSystemCollateralTX(CTransactionRef& tx, uint256 hash, CAmount amount, const COutPoint& outpoint=COutPoint()/*defaults null*/);
 
     bool BackupWallet(const std::string& strDest) const;
 

--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -750,6 +750,15 @@ bool WalletBatch::EraseDestData(const std::string &address, const std::string &k
     return EraseIC(std::make_pair(DBKeys::DESTDATA, std::make_pair(address, key)));
 }
 
+bool WalletBatch::WriteStakeSplitThreshold(const int nStakeSplitThreshold)
+{
+    return WriteIC(std::string("stakest"), nStakeSplitThreshold);
+}
+
+bool WalletBatch::WriteStakeCombineThreshold(const int nStakeCombineThreshold)
+{
+    return WriteIC(std::string("stakect"), nStakeCombineThreshold);
+}
 
 bool WalletBatch::WriteHDChain(const CHDChain& chain)
 {

--- a/src/wallet/walletdb.h
+++ b/src/wallet/walletdb.h
@@ -245,6 +245,10 @@ public:
     /// Erase destination data tuple from wallet database
     bool EraseDestData(const std::string &address, const std::string &key);
 
+    // Stake Split/Combine Thresholds
+    bool WriteStakeSplitThreshold(const int nStakeSplitThreshold);
+    bool WriteStakeCombineThreshold(const int nStakeCombineThreshold);
+
     DBErrors LoadWallet(CWallet* pwallet);
     DBErrors FindWalletTx(std::vector<uint256>& vTxHash, std::vector<CWalletTx>& vWtx);
     DBErrors ZapWalletTx(std::vector<CWalletTx>& vWtx);


### PR DESCRIPTION
Add chiabls, gmp components to depends. Switch serializationm for CTxOutCompressor back to legacy,
adapt some more methods for new ValidationState class, adapt collateral methods to rely less on wallet
routines, bring across allocator routines from legacy bitgreen, bring across a few legacy wallet routines,
adapt walletdb for proof of stake store.