### PR TITLE
Continued porting..

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -409,6 +409,7 @@ libbitcoin_server_a_SOURCES += \
   rpc/governance.cpp \
   rpc/quorum.cpp \
   rpc/special.cpp \
+  saltedhasher.cpp \
   special/cbtx.cpp \
   special/deterministicmns.cpp \
   special/mnauth.cpp \
@@ -603,6 +604,11 @@ libbitcoin_common_a_SOURCES += \
 libbitcoin_util_a_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES)
 libbitcoin_util_a_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)
 libbitcoin_util_a_SOURCES = \
+  bls/bls_batchverifier.h \
+  bls/bls_ies.cpp \
+  bls/bls_ies.h \
+  bls/bls_worker.cpp \
+  bls/bls_worker.h \
   support/lockedpool.cpp \
   chainparamsbase.cpp \
   clientversion.cpp \

--- a/src/addrman.cpp
+++ b/src/addrman.cpp
@@ -624,6 +624,23 @@ CAddrInfo CAddrMan::SelectTriedCollision_()
     return mapInfo[id_old];
 }
 
+CAddrInfo CAddrMan::GetAddressInfo_(const CService& addr)
+{
+    CAddrInfo* pinfo = Find(addr);
+
+    // if not found, bail out
+    if (!pinfo)
+        return CAddrInfo();
+
+    CAddrInfo& info = *pinfo;
+
+    // check whether we are talking about the exact same CService (including same port)
+    if (info != addr)
+        return CAddrInfo();
+
+    return *pinfo;
+}
+
 std::vector<bool> CAddrMan::DecodeAsmap(fs::path path)
 {
     std::vector<bool> bits;

--- a/src/addrman.h
+++ b/src/addrman.h
@@ -269,6 +269,9 @@ protected:
     //! Update an entry's service bits.
     void SetServices_(const CService &addr, ServiceFlags nServices) EXCLUSIVE_LOCKS_REQUIRED(cs);
 
+    //! Get address info for address
+    CAddrInfo GetAddressInfo_(const CService& addr);
+
 public:
     // Compressed IP->ASN mapping, loaded from a file when a node starts.
     // Should be always empty if no file was provided.
@@ -667,6 +670,17 @@ public:
         Check();
     }
 
+    CAddrInfo GetAddressInfo(const CService& addr)
+    {
+        CAddrInfo addrRet;
+        {
+            LOCK(cs);
+            Check();
+            addrRet = GetAddressInfo_(addr);
+            Check();
+        }
+        return addrRet;
+    }
 };
 
 #endif // BITCOIN_ADDRMAN_H

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -147,6 +147,9 @@ public:
         consensus.BIP34Hash = uint256();
         consensus.BIP65Height = 1;
         consensus.BIP66Height = 1;
+        consensus.CSVHeight = 1;
+        consensus.SegwitHeight = 1;
+        consensus.MinBIP9WarningHeight = 1;
         consensus.powLimit = uint256S("00000fffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"); // ~arith_uint256(0) >> 20;
         consensus.nPowTargetTimespan = 1 * 24 * 60 * 60;                                                   // 1 day
         consensus.nPowTargetSpacing = 1 * 60;

--- a/src/governance/governance.cpp
+++ b/src/governance/governance.cpp
@@ -1226,7 +1226,7 @@ void CGovernanceManager::RequestOrphanObjects(CConnman& connman)
     LogPrint(BCLog::GOBJECT, "CGovernanceObject::RequestOrphanObjects -- number objects = %d\n", vecHashesFiltered.size());
 
     for (const uint256& nHash : vecHashesFiltered) {
-        g_connman->ForEachNode([&, nHash](CNode* pnode) {
+        connman.ForEachNode([&, nHash](CNode* pnode) {
             if (pnode->fMasternode) {
                 return;
             }

--- a/src/governance/governance.h
+++ b/src/governance/governance.h
@@ -350,6 +350,7 @@ public:
     }
 
     void UpdatedBlockTip(const CBlockIndex* pindex, CConnman& connman);
+
     int64_t GetLastDiffTime() const { return nTimeLastDiff; }
     void UpdateLastDiffTime(int64_t nTimeIn) { nTimeLastDiff = nTimeIn; }
 

--- a/src/index/txindex.cpp
+++ b/src/index/txindex.cpp
@@ -17,31 +17,6 @@ constexpr char DB_TXINDEX_BLOCK = 'T';
 
 std::unique_ptr<TxIndex> g_txindex;
 
-struct CDiskTxPos : public FlatFilePos
-{
-    unsigned int nTxOffset; // after header
-
-    ADD_SERIALIZE_METHODS;
-
-    template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action) {
-        READWRITEAS(FlatFilePos, *this);
-        READWRITE(VARINT(nTxOffset));
-    }
-
-    CDiskTxPos(const FlatFilePos &blockIn, unsigned int nTxOffsetIn) : FlatFilePos(blockIn.nFile, blockIn.nPos), nTxOffset(nTxOffsetIn) {
-    }
-
-    CDiskTxPos() {
-        SetNull();
-    }
-
-    void SetNull() {
-        FlatFilePos::SetNull();
-        nTxOffset = 0;
-    }
-};
-
 /**
  * Access to the txindex database (indexes/txindex/)
  *

--- a/src/index/txindex.h
+++ b/src/index/txindex.h
@@ -9,6 +9,31 @@
 #include <index/base.h>
 #include <txdb.h>
 
+struct CDiskTxPos : public FlatFilePos
+{
+    unsigned int nTxOffset; // after header
+
+    ADD_SERIALIZE_METHODS;
+
+    template <typename Stream, typename Operation>
+    inline void SerializationOp(Stream& s, Operation ser_action) {
+        READWRITEAS(FlatFilePos, *this);
+        READWRITE(VARINT(nTxOffset));
+    }
+
+    CDiskTxPos(const FlatFilePos &blockIn, unsigned int nTxOffsetIn) : FlatFilePos(blockIn.nFile, blockIn.nPos), nTxOffset(nTxOffsetIn) {
+    }
+
+    CDiskTxPos() {
+        SetNull();
+    }
+
+    void SetNull() {
+        FlatFilePos::SetNull();
+        nTxOffset = 0;
+    }
+};
+
 /**
  * TxIndex is used to look up transactions included in the blockchain by hash.
  * The index is written to a LevelDB database and records the filesystem

--- a/src/indirectmap.h
+++ b/src/indirectmap.h
@@ -5,8 +5,6 @@
 #ifndef BITCOIN_INDIRECTMAP_H
 #define BITCOIN_INDIRECTMAP_H
 
-#include <map>
-
 template <class T>
 struct DereferencingComparator { bool operator()(const T a, const T b) const { return *a < *b; } };
 

--- a/src/interfaces/node.cpp
+++ b/src/interfaces/node.cpp
@@ -319,7 +319,14 @@ public:
                     /* verification progress is unused when a header was received */ 0);
             }));
     }
-    NodeContext* context() override { return &m_context; }
+    std::unique_ptr<Handler> handleNotifyAdditionalDataSyncProgressChanged(NotifyAdditionalDataSyncProgressChangedFn fn)
+    {
+        return MakeHandler(::uiInterface.NotifyAdditionalDataSyncProgressChanged_connect(fn));
+    }
+    std::unique_ptr<Handler> handleNotifyMasternodeListChanged(NotifyMasternodeListChangedFn fn) override
+    {
+        return MakeHandler(::uiInterface.NotifyMasternodeListChanged_connect(fn));
+    }
     NodeContext m_context;
 };
 

--- a/src/interfaces/node.h
+++ b/src/interfaces/node.h
@@ -27,6 +27,7 @@ class Coin;
 class RPCTimerInterface;
 class UniValue;
 class proxyType;
+class CDeterministicMNList;
 struct CNodeStateStats;
 struct NodeContext;
 enum class WalletCreationStatus;
@@ -257,7 +258,12 @@ public:
     virtual std::unique_ptr<Handler> handleNotifyHeaderTip(NotifyHeaderTipFn fn) = 0;
 
     //! Return pointer to internal chain interface, useful for testing.
-    virtual NodeContext* context() { return nullptr; }
+    using NotifyAdditionalDataSyncProgressChangedFn = std::function<void(double nProgress)>;
+    virtual std::unique_ptr<Handler> handleNotifyAdditionalDataSyncProgressChanged(NotifyAdditionalDataSyncProgressChangedFn fn) = 0;
+
+    using NotifyMasternodeListChangedFn =
+        std::function<void(const CDeterministicMNList& newList)>;
+    virtual std::unique_ptr<Handler> handleNotifyMasternodeListChanged(NotifyMasternodeListChangedFn fn) = 0;
 };
 
 //! Return implementation of Node interface.

--- a/src/llmq/quorums_blockprocessor.h
+++ b/src/llmq/quorums_blockprocessor.h
@@ -40,7 +40,7 @@ public:
 
     void ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStream& vRecv, CConnman* connman);
 
-    bool ProcessBlock(const CBlock& block, const CBlockIndex* pindex, TxValidationState& state);
+    bool ProcessBlock(const CBlock& block, const CBlockIndex* pindex, BlockValidationState& state);
     bool UndoBlock(const CBlock& block, const CBlockIndex* pindex);
 
     void AddMinableCommitment(const CFinalCommitment& fqc);

--- a/src/llmq/quorums_chainlocks.cpp
+++ b/src/llmq/quorums_chainlocks.cpp
@@ -31,6 +31,11 @@ std::string CChainLockSig::ToString() const
     return strprintf("CChainLockSig(nHeight=%d, blockHash=%s)", nHeight, blockHash.ToString());
 }
 
+CChainLocksHandler::CChainLocksHandler(CScheduler* _scheduler) :
+    scheduler(_scheduler)
+{
+}
+
 CChainLocksHandler::~CChainLocksHandler()
 {
 }
@@ -43,8 +48,7 @@ void CChainLocksHandler::Start()
         EnforceBestChainLock();
         // regularly retry signing the current chaintip as it might have failed before due to missing ixlocks
         TrySignChainTip();
-    },
-        (std::chrono::milliseconds)5000);
+    }, std::chrono::seconds{5});
 }
 
 void CChainLocksHandler::Stop()
@@ -155,8 +159,7 @@ void CChainLocksHandler::ProcessNewChainLock(NodeId from, const llmq::CChainLock
     scheduler->scheduleFromNow([&]() {
         CheckActiveState();
         EnforceBestChainLock();
-    },
-        (std::chrono::milliseconds)0);
+    }, std::chrono::seconds{0});
 
     LogPrint(BCLog::CHAINLOCKS, "CChainLocksHandler::%s -- processed new CLSIG (%s), peer=%d\n",
         __func__, clsig.ToString(), from);
@@ -200,8 +203,7 @@ void CChainLocksHandler::UpdatedBlockTip(const CBlockIndex* pindexNew)
         TrySignChainTip();
         LOCK(cs);
         tryLockChainTipScheduled = false;
-    },
-        (std::chrono::milliseconds)0);
+    }, std::chrono::seconds{0});
 }
 
 void CChainLocksHandler::CheckActiveState()

--- a/src/masternodes/activemasternode.cpp
+++ b/src/masternodes/activemasternode.cpp
@@ -56,7 +56,7 @@ std::string CActiveMasternodeManager::GetStatus() const
     }
 }
 
-void CActiveMasternodeManager::Init()
+void CActiveMasternodeManager::Init(const CBlockIndex* pindex)
 {
     LOCK(cs_main);
 
@@ -76,7 +76,7 @@ void CActiveMasternodeManager::Init()
         return;
     }
 
-    CDeterministicMNList mnList = deterministicMNManager->GetListAtChainTip();
+    CDeterministicMNList mnList = deterministicMNManager->GetListForBlock(pindex);
 
     CDeterministicMNCPtr dmn = mnList.GetMNByOperatorKey(*activeMasternodeInfo.blsPubKeyOperator);
     // MN not appeared on the chain yet
@@ -142,18 +142,18 @@ void CActiveMasternodeManager::UpdatedBlockTip(const CBlockIndex* pindexNew, con
             activeMasternodeInfo.proTxHash = uint256();
             activeMasternodeInfo.outpoint.SetNull();
             // MN might have reappeared in same block with a new ProTx
-            Init();
+            Init(pindexNew);
         } else if (mnList.GetMN(mnListEntry->proTxHash)->pdmnState->pubKeyOperator != mnListEntry->pdmnState->pubKeyOperator) {
             // MN operator key changed or revoked
             state = MASTERNODE_OPERATOR_KEY_CHANGED;
             activeMasternodeInfo.proTxHash = uint256();
             activeMasternodeInfo.outpoint.SetNull();
             // MN might have reappeared in same block with a new ProTx
-            Init();
+            Init(pindexNew);
         }
     } else {
         // MN might have (re)appeared with a new ProTx or we've found some peers and figured out our local address
-        Init();
+        Init(pindexNew);
     }
 }
 

--- a/src/masternodes/activemasternode.h
+++ b/src/masternodes/activemasternode.h
@@ -59,7 +59,7 @@ private:
 public:
     virtual void UpdatedBlockTip(const CBlockIndex* pindexNew, const CBlockIndex* pindexFork, bool fInitialDownload);
 
-    void Init();
+    void Init(const CBlockIndex* pindex);
 
     CDeterministicMNCPtr GetDMN() const { return mnListEntry; }
 

--- a/src/masternodes/meta.h
+++ b/src/masternodes/meta.h
@@ -21,7 +21,7 @@ class CMasternodeMetaInfo
     friend class CMasternodeMetaMan;
 
 private:
-    mutable RecursiveMutex  cs;
+    mutable RecursiveMutex cs;
 
     uint256 proTxHash;
 
@@ -81,7 +81,7 @@ class CMasternodeMetaMan
 private:
     static const std::string SERIALIZATION_VERSION_STRING;
 
-    RecursiveMutex  cs;
+    RecursiveMutex cs;
 
     std::map<uint256, CMasternodeMetaInfoPtr> metaInfos;
     std::vector<uint256> vecDirtyGovernanceObjectHashes;

--- a/src/masternodes/notificationinterface.h
+++ b/src/masternodes/notificationinterface.h
@@ -7,12 +7,10 @@
 
 #include <validationinterface.h>
 
-class CBlockIndex;
-
 class CMNNotificationInterface : public CValidationInterface
 {
 public:
-    CMNNotificationInterface(CConnman& connmanIn): connman(connmanIn) {}
+    explicit CMNNotificationInterface(CConnman& connmanIn): connman(connmanIn) {}
     virtual ~CMNNotificationInterface() = default;
 
     // a small helper to initialize current block height in sub-modules on startup
@@ -20,12 +18,14 @@ public:
 
 protected:
     // CValidationInterface
-    void AcceptedBlockHeader(const CBlockIndex *pindexNew) ;
-    void NotifyHeaderTip(const CBlockIndex *pindexNew, bool fInitialDownload) ;
-    void UpdatedBlockTip(const CBlockIndex *pindexNew, const CBlockIndex *pindexFork, bool fInitialDownload) ;
-    void SyncTransaction(const CTransaction &tx, const CBlockIndex *pindex, int posInBlock) ;
-    void NotifyMasternodeListChanged(bool undo, const CDeterministicMNList& oldMNList, const CDeterministicMNListDiff& diff) ;
-    void NotifyChainLock(const CBlockIndex* pindex) ;
+    void AcceptedBlockHeader(const CBlockIndex *pindexNew) override;
+    void NotifyHeaderTip(const CBlockIndex *pindexNew, bool fInitialDownload) override;
+    void SynchronousUpdatedBlockTip(const CBlockIndex *pindexNew, const CBlockIndex *pindexFork, bool fInitialDownload) override;
+    void UpdatedBlockTip(const CBlockIndex *pindexNew, const CBlockIndex *pindexFork, bool fInitialDownload) override;
+    void BlockConnected(const std::shared_ptr<const CBlock>& pblock, const CBlockIndex* pindex) override;
+    void BlockDisconnected(const std::shared_ptr<const CBlock>& pblock, const CBlockIndex* pindexDisconnected) override;
+    void NotifyMasternodeListChanged(bool undo, const CDeterministicMNList& oldMNList, const CDeterministicMNListDiff& diff) override;
+    void NotifyChainLock(const CBlockIndex* pindex) override;
 
 private:
     CConnman& connman;

--- a/src/masternodes/sync.cpp
+++ b/src/masternodes/sync.cpp
@@ -166,7 +166,7 @@ void CMasternodeSync::ProcessTick(CConnman& connman)
 
     std::vector<CNode*> vNodesCopy = connman.CopyNodeVector(CConnman::FullyConnectedOnly);
 
-    for (auto& pnode : vNodesCopy)
+    for (CNode* pnode : vNodesCopy)
     {
         CNetMsgMaker msgMaker(pnode->GetSendVersion());
 
@@ -281,7 +281,6 @@ void CMasternodeSync::ProcessTick(CConnman& connman)
                 }
                 netfulfilledman.AddFulfilledRequest(pnode->addr, "governance-sync");
 
-                if (pnode->nVersion < MIN_GOVERNANCE_PEER_PROTO_VERSION) continue;
                 nTriedPeerCount++;
 
                 SendGovernanceSyncRequest(pnode, connman);

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -49,6 +49,8 @@ static_assert(MINIUPNPC_API_VERSION >= 10, "miniUPnPc API version >= 10 assumed"
 
 #include <math.h>
 
+std::unique_ptr<CConnman> g_connman;
+
 // How often to dump addresses to peers.dat
 static constexpr std::chrono::minutes DUMP_PEERS_INTERVAL{15};
 
@@ -3089,7 +3091,7 @@ bool CConnman::IsMasternodeQuorumNode(const CNode* pnode)
 
 void CConnman::RelayInv(CInv &inv, const int minProtoVersion)
 {
-    g_connman->ForEachNode([&inv, minProtoVersion](CNode* node) {
+    ForEachNode([&inv, minProtoVersion](CNode* node) {
         if (node->nVersion < minProtoVersion) return;
         node->PushInventory(inv);
     });
@@ -3097,7 +3099,7 @@ void CConnman::RelayInv(CInv &inv, const int minProtoVersion)
 
 void CConnman::RelayInvFiltered(CInv &inv, const CTransaction &relatedTx, const int minProtoVersion)
 {
-    g_connman->ForEachNode([&inv, &relatedTx, minProtoVersion](CNode* node) {
+    ForEachNode([&inv, &relatedTx, minProtoVersion](CNode* node) {
         if (node->nVersion < minProtoVersion) return;
         {
             LOCK(node->cs_filter);
@@ -3110,7 +3112,7 @@ void CConnman::RelayInvFiltered(CInv &inv, const CTransaction &relatedTx, const 
 
 void CConnman::RelayInvFiltered(CInv &inv, const uint256 &relatedTxHash, const int minProtoVersion)
 {
-    g_connman->ForEachNode([&inv, &relatedTxHash, minProtoVersion](CNode* node) {
+    ForEachNode([&inv, &relatedTxHash, minProtoVersion](CNode* node) {
         if (node->nVersion < minProtoVersion) return;
         {
             LOCK(node->cs_filter);

--- a/src/net_processing.h
+++ b/src/net_processing.h
@@ -94,7 +94,8 @@ bool IsBanned(NodeId nodeid);
 /** Relay transaction to every node */
 void RequestData(const NodeId id, const CInv& inv) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 bool RequestDataAvailable(const NodeId id, size_t nNewDataSize);
-extern void RemoveDataRequest(const NodeId id, const CInv& inv) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
+void RemoveDataRequest(const NodeId id, const CInv& inv) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
+
 /** Misbehaviour */
 void Misbehaving(NodeId nodeid, int howmuch, const std::string& message="") EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 #endif // BITCOIN_NET_PROCESSING_H

--- a/src/pos/sign.cpp
+++ b/src/pos/sign.cpp
@@ -10,6 +10,7 @@
 #include <primitives/block.h>
 #include <script/standard.h>
 #include <wallet/wallet.h>
+#include <wallet/rpcwallet.h>
 
 typedef std::vector<unsigned char> valtype;
 
@@ -34,7 +35,8 @@ bool CBlockSigner::SignBlock()
         keyID = CPubKey(vSolutions[0]).GetID();
 
     CKey key;
-    if (!wallet->GetKey(keyID, key)) return false;
+    LegacyScriptPubKeyMan& spk_man = EnsureLegacyScriptPubKeyMan(*wallet);
+    if (!spk_man.GetKey(keyID, key)) return false;
     if (!key.Sign(block.GetHash(), block.vchBlockSig)) return false;
     return true;
 }

--- a/src/pow.cpp
+++ b/src/pow.cpp
@@ -12,6 +12,44 @@
 
 unsigned int GetNextWorkRequired(const CBlockIndex* pindexLast, const CBlockHeader *pblock, const Consensus::Params& params)
 {
+    if (pindexLast->nHeight + 1 >= params.nLastPoWBlock)
+        return GetNextRequiredPoS(pindexLast, params);
+
+    return GetNextRequiredPoW(pindexLast, pblock, params);
+}
+
+// proof-of-stake
+unsigned int GetNextRequiredPoS(const CBlockIndex* pindexLast, const Consensus::Params& params)
+{
+    if (pindexLast == nullptr)
+        return UintToArith256(params.powLimit).GetCompact(); // genesis block
+
+    int64_t nActualSpacing = 0;
+    if (pindexLast->nHeight != 0)
+        nActualSpacing = pindexLast->GetBlockTime() - pindexLast->pprev->GetBlockTime();
+
+    if (nActualSpacing < 0)
+        nActualSpacing = 1;
+
+    // target change every block
+    // retarget with exponential moving toward target spacing
+    const arith_uint256 bnTargetLimit = UintToArith256(params.powLimit);
+    arith_uint256 bnNew;
+    bnNew.SetCompact(pindexLast->nBits);
+
+    int64_t nTargetSpacing = params.nPosTargetSpacing;
+    int64_t nInterval = params.nPosTargetTimespan / nTargetSpacing;
+    bnNew *= ((nInterval - 1) * nTargetSpacing + nActualSpacing + nActualSpacing);
+    bnNew /= ((nInterval + 1) * nTargetSpacing);
+
+    if (bnNew <= 0 || bnNew > bnTargetLimit)
+        bnNew = bnTargetLimit;
+
+    return bnNew.GetCompact();
+}
+
+unsigned int GetNextRequiredPoW(const CBlockIndex* pindexLast, const CBlockHeader *pblock, const Consensus::Params& params)
+{
     assert(pindexLast != nullptr);
     unsigned int nProofOfWorkLimit = UintToArith256(params.powLimit).GetCompact();
 

--- a/src/pow.h
+++ b/src/pow.h
@@ -15,6 +15,8 @@ class CBlockIndex;
 class uint256;
 
 unsigned int GetNextWorkRequired(const CBlockIndex* pindexLast, const CBlockHeader *pblock, const Consensus::Params&);
+unsigned int GetNextRequiredPoS(const CBlockIndex* pindexLast, const Consensus::Params& params);
+unsigned int GetNextRequiredPoW(const CBlockIndex* pindexLast, const CBlockHeader *pblock, const Consensus::Params& params);
 unsigned int CalculateNextWorkRequired(const CBlockIndex* pindexLast, int64_t nFirstBlockTime, const Consensus::Params&);
 
 /** Check whether a block hash satisfies the proof-of-work requirement specified by nBits */

--- a/src/pubkey.h
+++ b/src/pubkey.h
@@ -219,6 +219,11 @@ struct CExtPubKey {
             a.pubkey == b.pubkey;
     }
 
+    friend bool operator!=(const CExtPubKey &a, const CExtPubKey &b)
+    {
+        return !(a == b);
+    }
+
     void Encode(unsigned char code[BIP32_EXTKEY_SIZE]) const;
     void Decode(const unsigned char code[BIP32_EXTKEY_SIZE]);
     bool Derive(CExtPubKey& out, unsigned int nChild) const;

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -369,6 +369,17 @@ static void NotifyTransactionChanged(WalletModel *walletmodel, const uint256 &ha
     assert(invoked);
 }
 
+static void NotifyISLockReceived(WalletModel *walletmodel)
+{
+    QMetaObject::invokeMethod(walletmodel, "updateNumISLocks", Qt::QueuedConnection);
+}
+
+static void NotifyChainLockReceived(WalletModel *walletmodel, int chainLockHeight)
+{
+    QMetaObject::invokeMethod(walletmodel, "updateChainLockHeight", Qt::QueuedConnection,
+                              Q_ARG(int, chainLockHeight));
+}
+
 static void ShowProgress(WalletModel *walletmodel, const std::string &title, int nProgress)
 {
     // emits signal "showProgress"

--- a/src/random.cpp
+++ b/src/random.cpp
@@ -5,6 +5,8 @@
 
 #include <random.h>
 
+#include <compat/cpuid.h>
+#include <crypto/sha256.h>
 #include <crypto/sha512.h>
 #include <support/cleanse.h>
 #ifdef WIN32
@@ -18,6 +20,8 @@
 #include <stdlib.h>
 #include <chrono>
 #include <thread>
+
+#include <randomenv.h>
 
 #include <support/allocators/secure.h>
 
@@ -40,16 +44,6 @@
 #include <util/strencodings.h> // for ARRAYLEN
 #include <sys/sysctl.h>
 #endif
-
-#include <mutex>
-
-#if defined(__x86_64__) || defined(__amd64__) || defined(__i386__)
-#include <cpuid.h>
-#endif
-
-#include <openssl/err.h>
-#include <openssl/rand.h>
-#include <openssl/conf.h>
 
 [[noreturn]] static void RandFailure()
 {
@@ -88,15 +82,6 @@ static_assert(CPUID_F1_ECX_RDRAND == bit_RDRND, "Unexpected value for bit_RDRND"
 #ifdef bit_RDSEED
 static_assert(CPUID_F7_EBX_RDSEED == bit_RDSEED, "Unexpected value for bit_RDSEED");
 #endif
-static void inline GetCPUID(uint32_t leaf, uint32_t subleaf, uint32_t& a, uint32_t& b, uint32_t& c, uint32_t& d)
-{
-    // We can't use __get_cpuid as it doesn't support subleafs.
-#ifdef __GNUC__
-    __cpuid_count(leaf, subleaf, a, b, c, d);
-#else
-    __asm__ ("cpuid" : "=a"(a), "=b"(b), "=c"(c), "=d"(d) : "0"(leaf), "2"(subleaf));
-#endif
-}
 
 static void InitHardwareRand()
 {
@@ -398,8 +383,6 @@ void GetOSRand(unsigned char *ent32)
 #endif
 }
 
-void LockingCallbackOpenSSL(int mode, int i, const char* file, int line);
-
 namespace {
 
 class RNGState {
@@ -415,31 +398,47 @@ class RNGState {
     unsigned char m_state[32] GUARDED_BY(m_mutex) = {0};
     uint64_t m_counter GUARDED_BY(m_mutex) = 0;
     bool m_strongly_seeded GUARDED_BY(m_mutex) = false;
-    std::unique_ptr<Mutex[]> m_mutex_openssl;
+
+    Mutex m_events_mutex;
+    CSHA256 m_events_hasher GUARDED_BY(m_events_mutex);
 
 public:
     RNGState() noexcept
     {
         InitHardwareRand();
-
-        // Init OpenSSL library multithreading support
-        m_mutex_openssl.reset(new Mutex[CRYPTO_num_locks()]);
-        CRYPTO_set_locking_callback(LockingCallbackOpenSSL);
-
-        // OpenSSL can optionally load a config file which lists optional loadable modules and engines.
-        // We don't use them so we don't require the config. However some of our libs may call functions
-        // which attempt to load the config file, possibly resulting in an exit() or crash if it is missing
-        // or corrupt. Explicitly tell OpenSSL not to try to load the file. The result for our libs will be
-        // that the config appears to have been loaded and there are no modules/engines available.
-        OPENSSL_no_config();
     }
 
     ~RNGState()
     {
-        // Securely erase the memory used by the OpenSSL PRNG
-        RAND_cleanup();
-        // Shutdown OpenSSL library multithreading support
-        CRYPTO_set_locking_callback(nullptr);
+    }
+
+    void AddEvent(uint32_t event_info) noexcept
+    {
+        LOCK(m_events_mutex);
+
+        m_events_hasher.Write((const unsigned char *)&event_info, sizeof(event_info));
+        // Get the low four bytes of the performance counter. This translates to roughly the
+        // subsecond part.
+        uint32_t perfcounter = (GetPerformanceCounter() & 0xffffffff);
+        m_events_hasher.Write((const unsigned char*)&perfcounter, sizeof(perfcounter));
+    }
+
+    /**
+     * Feed (the hash of) all events added through AddEvent() to hasher.
+     */
+    void SeedEvents(CSHA512& hasher) noexcept
+    {
+        // We use only SHA256 for the events hashing to get the ASM speedups we have for SHA256,
+        // since we want it to be fast as network peers may be able to trigger it repeatedly.
+        LOCK(m_events_mutex);
+
+        unsigned char events_hash[32];
+        m_events_hasher.Finalize(events_hash);
+        hasher.Write(events_hash, 32);
+
+        // Re-initialize the hasher with the finalized state to use later.
+        m_events_hasher.Reset();
+        m_events_hasher.Write(events_hash, 32);
     }
 
     /** Extract up to 32 bytes of entropy from the RNG state, mixing in new entropy from hasher.
@@ -475,8 +474,6 @@ public:
         memory_cleanse(buf, 64);
         return ret;
     }
-
-    Mutex& GetOpenSSLMutex(int i) { return m_mutex_openssl[i]; }
 };
 
 RNGState& GetRNGState() noexcept
@@ -486,17 +483,6 @@ RNGState& GetRNGState() noexcept
     static std::vector<RNGState, secure_allocator<RNGState>> g_rng(1);
     return g_rng[0];
 }
-}
-
-void LockingCallbackOpenSSL(int mode, int i, const char* file, int line) NO_THREAD_SAFETY_ANALYSIS
-{
-    RNGState& rng = GetRNGState();
-
-    if (mode & CRYPTO_LOCK) {
-        rng.GetOpenSSLMutex(i).lock();
-    } else {
-        rng.GetOpenSSLMutex(i).unlock();
-    }
 }
 
 /* A note on the use of noexcept in the seeding functions below:
@@ -535,7 +521,7 @@ static void SeedFast(CSHA512& hasher) noexcept
     SeedTimestamp(hasher);
 }
 
-static void SeedSlow(CSHA512& hasher) noexcept
+static void SeedSlow(CSHA512& hasher, RNGState& rng) noexcept
 {
     unsigned char buffer[32];
 
@@ -546,9 +532,8 @@ static void SeedSlow(CSHA512& hasher) noexcept
     GetOSRand(buffer);
     hasher.Write(buffer, sizeof(buffer));
 
-    // OpenSSL RNG (for now)
-    RAND_bytes(buffer, sizeof(buffer));
-    hasher.Write(buffer, sizeof(buffer));
+    // Add the events hasher into the mix
+    rng.SeedEvents(hasher);
 
     // High-precision timestamp.
     //
@@ -558,22 +543,16 @@ static void SeedSlow(CSHA512& hasher) noexcept
 }
 
 /** Extract entropy from rng, strengthen it, and feed it into hasher. */
-static void SeedStrengthen(CSHA512& hasher, RNGState& rng) noexcept
+static void SeedStrengthen(CSHA512& hasher, RNGState& rng, int microseconds) noexcept
 {
-    static std::atomic<int64_t> last_strengthen{0};
-    int64_t last_time = last_strengthen.load();
-    int64_t current_time = GetTimeMicros();
-    if (current_time > last_time + 60000000) { // Only run once a minute
-        // Generate 32 bytes of entropy from the RNG, and a copy of the entropy already in hasher.
-        unsigned char strengthen_seed[32];
-        rng.MixExtract(strengthen_seed, sizeof(strengthen_seed), CSHA512(hasher), false);
-        // Strengthen it for 10ms (100ms on first run), and feed it into hasher.
-        Strengthen(strengthen_seed, last_time == 0 ? 100000 : 10000, hasher);
-        last_strengthen = current_time;
-    }
+    // Generate 32 bytes of entropy from the RNG, and a copy of the entropy already in hasher.
+    unsigned char strengthen_seed[32];
+    rng.MixExtract(strengthen_seed, sizeof(strengthen_seed), CSHA512(hasher), false);
+    // Strengthen the seed, and feed it into hasher.
+    Strengthen(strengthen_seed, microseconds, hasher);
 }
 
-static void SeedSleep(CSHA512& hasher, RNGState& rng)
+static void SeedPeriodic(CSHA512& hasher, RNGState& rng) noexcept
 {
     // Everything that the 'fast' seeder includes
     SeedFast(hasher);
@@ -581,42 +560,40 @@ static void SeedSleep(CSHA512& hasher, RNGState& rng)
     // High-precision timestamp
     SeedTimestamp(hasher);
 
-    // Sleep for 1ms
-    MilliSleep(1);
+    // Add the events hasher into the mix
+    rng.SeedEvents(hasher);
 
-    // High-precision timestamp after sleeping (as we commit to both the time before and after, this measures the delay)
-    SeedTimestamp(hasher);
+    // Dynamic environment data (performance monitoring, ...)
+    auto old_size = hasher.Size();
+    RandAddDynamicEnv(hasher);
 
-    // Windows performance monitor data (once every 10 minutes)
-    RandAddSeedPerfmon(hasher);
-
-    // Strengthen every minute
-    SeedStrengthen(hasher, rng);
+    // Strengthen for 10 ms
+    SeedStrengthen(hasher, rng, 10000);
 }
 
 static void SeedStartup(CSHA512& hasher, RNGState& rng) noexcept
 {
-#ifdef WIN32
-    RAND_screen();
-#endif
-
     // Gather 256 bits of hardware randomness, if available
     SeedHardwareSlow(hasher);
 
     // Everything that the 'slow' seeder includes.
-    SeedSlow(hasher);
+    SeedSlow(hasher, rng);
 
-    // Windows performance monitor data.
-    RandAddSeedPerfmon(hasher);
+    // Dynamic environment data (performance monitoring, ...)
+    auto old_size = hasher.Size();
+    RandAddDynamicEnv(hasher);
 
-    // Strengthen
-    SeedStrengthen(hasher, rng);
+    // Static environment data
+    RandAddStaticEnv(hasher);
+
+    // Strengthen for 100 ms
+    SeedStrengthen(hasher, rng, 100000);
 }
 
 enum class RNGLevel {
     FAST, //!< Automatically called by GetRandBytes
     SLOW, //!< Automatically called by GetStrongRandBytes
-    SLEEP, //!< Called by RandAddSeedSleep()
+    PERIODIC, //!< Called by RandAddPeriodic()
 };
 
 static void ProcRand(unsigned char* out, int num, RNGLevel level)
@@ -632,10 +609,10 @@ static void ProcRand(unsigned char* out, int num, RNGLevel level)
         SeedFast(hasher);
         break;
     case RNGLevel::SLOW:
-        SeedSlow(hasher);
+        SeedSlow(hasher, rng);
         break;
-    case RNGLevel::SLEEP:
-        SeedSleep(hasher, rng);
+    case RNGLevel::PERIODIC:
+        SeedPeriodic(hasher, rng);
         break;
     }
 
@@ -646,21 +623,12 @@ static void ProcRand(unsigned char* out, int num, RNGLevel level)
         SeedStartup(startup_hasher, rng);
         rng.MixExtract(out, num, std::move(startup_hasher), true);
     }
-
-    // For anything but the 'fast' level, feed the resulting RNG output (after an additional hashing step) back into OpenSSL.
-    if (level != RNGLevel::FAST) {
-        unsigned char buf[64];
-        CSHA512().Write(out, num).Finalize(buf);
-        RAND_add(buf, sizeof(buf), num);
-        memory_cleanse(buf, 64);
-    }
 }
 
 void GetRandBytes(unsigned char* buf, int num) noexcept { ProcRand(buf, num, RNGLevel::FAST); }
 void GetStrongRandBytes(unsigned char* buf, int num) noexcept { ProcRand(buf, num, RNGLevel::SLOW); }
 void RandAddPeriodic() noexcept { ProcRand(nullptr, 0, RNGLevel::PERIODIC); }
 void RandAddEvent(const uint32_t event_info) noexcept { GetRNGState().AddEvent(event_info); }
-void RandAddSeedSleep() { ProcRand(nullptr, 0, RNGLevel::SLEEP); }
 
 bool g_mock_deterministic_tests{false};
 

--- a/src/random.h
+++ b/src/random.h
@@ -11,7 +11,7 @@
 #include <uint256.h>
 
 #include <chrono>
-#include <stdint.h>
+#include <cstdint>
 #include <limits>
 
 /**
@@ -86,12 +86,26 @@ bool GetRandBool(double rate);
 void GetStrongRandBytes(unsigned char* buf, int num) noexcept;
 
 /**
+ * Gather entropy from various expensive sources, and feed them to the PRNG state.
+ *
+ * Thread-safe.
+ */
+void RandAddPeriodic() noexcept;
+
+/**
+ * Gathers entropy from the low bits of the time at which events occur. Should
+ * be called with a uint32_t describing the event at the time an event occurs.
+ *
+ * Thread-safe.
+ */
+void RandAddEvent(const uint32_t event_info) noexcept;
+
+/**
  * Sleep for 1ms, gather entropy from various sources, and feed them to the PRNG state.
  *
  * Thread-safe.
  */
 void RandAddSeedSleep();
-void RandAddEvent(const uint32_t event_info) noexcept;
 
 /**
  * Fast randomness source. This is seeded once with secure random data, but

--- a/src/rpc/governance.cpp
+++ b/src/rpc/governance.cpp
@@ -217,7 +217,7 @@ UniValue gobject_prepare(const JSONRPCRequest& request)
     // -- send the tx to the network
     BlockValidationState state;
     mapValue_t mapValue;
-    if (!pwallet->CommitTransaction(tx, std::move(mapValue), {}, state)) {
+    if (!pwallet->CommitTransaction(tx, std::move(mapValue), {})) {
         throw JSONRPCError(RPC_INTERNAL_ERROR, "CommitTransaction failed! Reason given: " + state.GetRejectReason());
     }
 
@@ -552,7 +552,8 @@ UniValue gobject_vote_many(const JSONRPCRequest& request)
     auto mnList = deterministicMNManager->GetListAtChainTip();
     mnList.ForEachMN(true, [&](const CDeterministicMNCPtr& dmn) {
         CKey votingKey;
-        if (pwallet->GetKey(dmn->pdmnState->keyIDVoting, votingKey)) {
+        LegacyScriptPubKeyMan& spk_man = EnsureLegacyScriptPubKeyMan(*pwallet);
+        if (spk_man.GetKey(dmn->pdmnState->keyIDVoting, votingKey)) {
             votingKeys.emplace(dmn->proTxHash, votingKey);
         }
     });
@@ -609,7 +610,8 @@ UniValue gobject_vote_alias(const JSONRPCRequest& request)
     }
 
     CKey votingKey;
-    if (!pwallet->GetKey(dmn->pdmnState->keyIDVoting, votingKey)) {
+    LegacyScriptPubKeyMan& spk_man = EnsureLegacyScriptPubKeyMan(*pwallet);
+    if (!spk_man.GetKey(dmn->pdmnState->keyIDVoting, votingKey)) {
         throw JSONRPCError(RPC_INVALID_PARAMETER, "Private key for voting address not known by wallet");
     }
 

--- a/src/rpc/governance.cpp
+++ b/src/rpc/governance.cpp
@@ -13,6 +13,8 @@
 #include <validation.h>
 #include <masternodes/sync.h>
 #include <messagesigner.h>
+#include <node/context.h>
+#include <rpc/blockchain.h>
 #include <rpc/protocol.h>
 #include <rpc/server.h>
 #include <rpc/util.h>
@@ -329,9 +331,9 @@ UniValue gobject_submit(const JSONRPCRequest& request)
 
     if (fMissingConfirmations) {
         governance.AddPostponedObject(govobj);
-        govobj.Relay(*g_connman);
+        govobj.Relay(*g_rpc_node->connman);
     } else {
-        governance.AddGovernanceObject(govobj, *g_connman);
+        governance.AddGovernanceObject(govobj, *g_rpc_node->connman);
     }
 
     return govobj.GetHash().ToString();
@@ -423,7 +425,7 @@ UniValue gobject_vote_conf(const JSONRPCRequest& request)
     }
 
     CGovernanceException exception;
-    if (governance.ProcessVoteAndRelay(vote, exception, *g_connman)) {
+    if (governance.ProcessVoteAndRelay(vote, exception, *g_rpc_node->connman)) {
         nSuccessful++;
         statusObj.pushKV("result", "success");
     } else {
@@ -486,7 +488,7 @@ UniValue VoteWithMasternodes(const std::map<uint256, CKey>& keys,
         }
 
         CGovernanceException exception;
-        if (governance.ProcessVoteAndRelay(vote, exception, *g_connman)) {
+        if (governance.ProcessVoteAndRelay(vote, exception, *g_rpc_node->connman)) {
             nSuccessful++;
             statusObj.pushKV("result", "success");
         } else {
@@ -1019,7 +1021,7 @@ UniValue voteraw(const JSONRPCRequest& request)
     }
 
     CGovernanceException exception;
-    if (governance.ProcessVoteAndRelay(vote, exception, *g_connman)) {
+    if (governance.ProcessVoteAndRelay(vote, exception, *g_rpc_node->connman)) {
         return "Voted successfully";
     } else {
         throw JSONRPCError(RPC_INTERNAL_ERROR, "Error voting : " + exception.GetMessage());

--- a/src/rpc/quorum.cpp
+++ b/src/rpc/quorum.cpp
@@ -17,25 +17,22 @@
 void quorum_list_help()
 {
     throw std::runtime_error(
-        RPCHelpMan{"quorum list", "",
-            {
-                {"count", RPCArg::Type::NUM, RPCArg::Optional::OMITTED, "Number of quorums to list. Will list active quorums.\n"
-                    "                   if \"count\" is not specified."}
-            },
-            RPCResult{
+            "quorum list ( count )\n"
+            "List of on-chain quorums\n"
+            "\nArguments:\n"
+            "1. count           (number, optional) Number of quorums to list. Will list active quorums\n"
+            "                   if \"count\" is not specified.\n"
+            "\nResult:\n"
                 "{\n"
                 "  \"quorumName\" : [                    (array of strings) List of quorum hashes per some quorum type.\n"
                 "     \"quorumHash\"                     (string) Quorum hash. Note: most recent quorums come first.\n"
                 "     ,...\n"
                 "  ],\n"
                 "}\n"
-            },
-            RPCExamples{
-                HelpExampleCli("quorum", "list") +
-                HelpExampleCli("quorum", "list 10") +
-                HelpExampleRpc("quorum", "list, 10")
-            }
-        }.ToString()
+            "\nExamples:\n"
+            + HelpExampleCli("quorum", "list")
+            + HelpExampleCli("quorum", "list 10")
+            + HelpExampleRpc("quorum", "list, 10")
     );
 }
 
@@ -414,12 +411,12 @@ UniValue quorum_dkgsimerror(const JSONRPCRequest& request)
 [[ noreturn ]] void quorum_help()
 {
     throw std::runtime_error(
-        RPCHelpMan{"quorum",
-            "\nSet of commands for quorums/LLMQ actions.\n",
-            {
-                {"command", RPCArg::Type::STR, /* default */ "all commands", "The command to get help on"},
-            },
-            RPCResult{
+            "quorum \"command\" ...\n"
+            "Set of commands for quorums/LLMQs.\n"
+            "To get help on individual commands, use \"help quorum command\".\n"
+            "\nArguments:\n"
+            "1. \"command\"        (string, required) The command to execute\n"
+            "\nAvailable commands:\n"
                 "  list              - List of on-chain quorums\n"
                 "  info              - Return information about a quorum\n"
                 "  dkgsimerror       - Simulates DKG errors and malicious behavior.\n"
@@ -429,9 +426,6 @@ UniValue quorum_dkgsimerror(const JSONRPCRequest& request)
                 "  hasrecsig         - Test if a valid recovered signature is present\n"
                 "  getrecsig         - Get a recovered signature\n"
                 "  isconflicting     - Test if a conflict exists\n"
-            },
-            RPCExamples{""},
-        }.ToString()
     );
 }
 

--- a/src/rpc/special.cpp
+++ b/src/rpc/special.cpp
@@ -34,67 +34,81 @@
 extern UniValue sendrawtransaction(const JSONRPCRequest& request);
 #endif//ENABLE_WALLET
 
-RPCArg GetHelpArg(std::string strParamName)
+std::string GetHelpString(int nParamNum, std::string strParamName)
 {
-    static const std::map<std::string, RPCArg> mapParamHelp = {
+    static const std::map<std::string, std::string> mapParamHelp = {
         {"collateralAddress",
-            {"collateralAddress", RPCArg::Type::STR, RPCArg::Optional::NO, "The bitgreen address to send the collateral to"},
+            "%d. \"collateralAddress\"        (string, required) The dash address to send the collateral to.\n"
         },
         {"collateralHash",
-            {"collateralHash", RPCArg::Type::STR, RPCArg::Optional::NO, "The collateral transaction hash."}
+            "%d. \"collateralHash\"           (string, required) The collateral transaction hash.\n"
         },
         {"collateralIndex",
-            {"collateralIndex", RPCArg::Type::NUM, RPCArg::Optional::NO, "The collateral transaction output index."}
+            "%d. collateralIndex            (numeric, required) The collateral transaction output index.\n"
         },
         {"feeSourceAddress",
-            {"feeSourceAddress", RPCArg::Type::STR, RPCArg::Optional::OMITTED, "If specified wallet will only use coins from this address to fund ProTx.\n"
+            "%d. \"feeSourceAddress\"         (string, optional) If specified wallet will only use coins from this address to fund ProTx.\n"
             "                              If not specified, payoutAddress is the one that is going to be used.\n"
-            "                              The private key belonging to this address must be known in your wallet."}
+            "                              The private key belonging to this address must be known in your wallet.\n"
         },
         {"fundAddress",
-            {"fundAddress", RPCArg::Type::STR, RPCArg::Optional::OMITTED, "If specified wallet will only use coins from this address to fund ProTx.\n"
+            "%d. \"fundAddress\"              (string, optional) If specified wallet will only use coins from this address to fund ProTx.\n"
             "                              If not specified, payoutAddress is the one that is going to be used.\n"
-            "                              The private key belonging to this address must be known in your wallet."}
+            "                              The private key belonging to this address must be known in your wallet.\n"
         },
         {"ipAndPort",
-            {"ipAndPort", RPCArg::Type::STR, RPCArg::Optional::NO, "IP and port in the form \"IP:PORT\".\n"
-            "                              Must be unique on the network. Can be set to 0, which will require a ProUpServTx afterwards."}
+            "%d. \"ipAndPort\"                (string, required) IP and port in the form \"IP:PORT\".\n"
+            "                              Must be unique on the network. Can be set to 0, which will require a ProUpServTx afterwards.\n"
         },
         {"operatorKey",
-            {"operatorKey", RPCArg::Type::STR, RPCArg::Optional::NO, "The operator private key belonging to the\n"
-            "                              registered operator public key."}
+            "%d. \"operatorKey\"              (string, required) The operator private key belonging to the\n"
+            "                              registered operator public key.\n"
         },
         {"operatorPayoutAddress",
-            {"operatorPayoutAddress", RPCArg::Type::STR, RPCArg::Optional::OMITTED, "The address used for operator reward payments.\n"
+            "%d. \"operatorPayoutAddress\"    (string, optional) The address used for operator reward payments.\n"
             "                              Only allowed when the ProRegTx had a non-zero operatorReward value.\n"
-            "                              If set to an empty string, the currently active payout address is reused."}
+            "                              If set to an empty string, the currently active payout address is reused.\n"
         },
-        {"operatorPubKey",
-            {"operatorPubKey", RPCArg::Type::STR, RPCArg::Optional::NO, "The operator BLS public key. The private key does not have to be known.\n"
-            "                              It has to match the private key which is later used when operating the masternode."}
+        {"operatorPubKey_register",
+            "%d. \"operatorPubKey\"           (string, required) The operator BLS public key. The private key does not have to be known.\n"
+            "                              It has to match the private key which is later used when operating the masternode.\n"
+        },
+        {"operatorPubKey_update",
+            "%d. \"operatorPubKey\"           (string, required) The operator BLS public key. The private key does not have to be known.\n"
+            "                              It has to match the private key which is later used when operating the masternode.\n"
+            "                              If set to an empty string, the currently active operator BLS public key is reused.\n"
         },
         {"operatorReward",
-            {"operatorReward", RPCArg::Type::NUM, RPCArg::Optional::NO, "The fraction in %% to share with the operator. The value must be\n"
-            "                              between 0.00 and 100.00."}
+            "%d. \"operatorReward\"           (numeric, required) The fraction in %% to share with the operator. The value must be\n"
+            "                              between 0.00 and 100.00.\n"
         },
         {"ownerAddress",
-            {"ownerAddress", RPCArg::Type::STR, RPCArg::Optional::NO, "The bitgreen address to use for payee updates and proposal voting.\n"
+            "%d. \"ownerAddress\"             (string, required) The dash address to use for payee updates and proposal voting.\n"
             "                              The private key belonging to this address must be known in your wallet. The address must\n"
-            "                              be unused and must differ from the collateralAddress."}
+            "                              be unused and must differ from the collateralAddress\n"
         },
-        {"payoutAddress",
-            {"payoutAddress", RPCArg::Type::STR, RPCArg::Optional::NO, "The bitgreen address to use for masternode reward payments."}
+        {"payoutAddress_register",
+            "%d. \"payoutAddress\"            (string, required) The dash address to use for masternode reward payments.\n"
+        },
+        {"payoutAddress_update",
+            "%d. \"payoutAddress\"            (string, required) The dash address to use for masternode reward payments.\n"
+            "                              If set to an empty string, the currently active payout address is reused.\n"
         },
         {"proTxHash",
-            {"proTxHash", RPCArg::Type::STR, RPCArg::Optional::NO, "The hash of the initial ProRegTx."}
+            "%d. \"proTxHash\"                (string, required) The hash of the initial ProRegTx.\n"
         },
         {"reason",
-            {"reason", RPCArg::Type::NUM, RPCArg::Optional::OMITTED, "The reason for masternode service revocation."}
+            "%d. reason                     (numeric, optional) The reason for masternode service revocation.\n"
         },
-        {"votingAddress",
-            {"votingAddress", RPCArg::Type::STR, RPCArg::Optional::NO, "The voting key address. The private key does not have to be known by your wallet.\n"
+        {"votingAddress_register",
+            "%d. \"votingAddress\"            (string, required) The voting key address. The private key does not have to be known by your wallet.\n"
             "                              It has to match the private key which is later used when voting on proposals.\n"
-            "                              If set to an empty string, ownerAddress will be used."}
+            "                              If set to an empty string, ownerAddress will be used.\n"
+        },
+        {"votingAddress_update",
+            "%d. \"votingAddress\"            (string, required) The voting key address. The private key does not have to be known by your wallet.\n"
+            "                              It has to match the private key which is later used when voting on proposals.\n"
+            "                              If set to an empty string, the currently active voting key address is reused.\n"
         },
     };
 
@@ -102,51 +116,53 @@ RPCArg GetHelpArg(std::string strParamName)
     if (it == mapParamHelp.end())
         throw std::runtime_error(strprintf("FIXME: WRONG PARAM NAME %s!", strParamName));
 
-    return it->second;
+    return strprintf(it->second, nParamNum);
 }
 
 // Allows to specify BitGreen address or priv key. In case of BitGreen address, the priv key is taken from the wallet
-static CKey ParsePrivKey(const CWallet* pwallet, const std::string &strKeyOrAddress, bool allowAddresses = true) {
-    CTxDestination address = DecodeDestination(strKeyOrAddress);
-    if (allowAddresses && IsValidDestination(address)) {
+static CKey ParsePrivKey(CWallet* pwallet, const std::string &strKeyOrAddress, bool allowAddresses = true) {
 #ifdef ENABLE_WALLET
-        if (!pwallet) {
-            throw std::runtime_error("Addresses not supported when wallet is disabled");
-        }
-        EnsureWalletIsUnlocked(pwallet);
-        CKeyID keyId;
-        CKey key;
-        keyId = GetKeyForDestination(*pwallet, address);
-        if (keyId.IsNull()) {
-            throw JSONRPCError(RPC_TYPE_ERROR, "Address does not refer to a key");
-        }
-        if (!pwallet->GetKey(keyId, key)) {
-            throw JSONRPCError(RPC_WALLET_ERROR, "Private key for address " + strKeyOrAddress + " is not known");
-        }
-        return key;
-#else//ENABLE_WALLET
-        throw std::runtime_error("Addresses not supported in no-wallet builds");
-#endif//ENABLE_WALLET
+    if (!pwallet) {
+        throw std::runtime_error("addresses not supported when wallet is disabled");
     }
+    LegacyScriptPubKeyMan& spk_man = EnsureLegacyScriptPubKeyMan(*pwallet);
 
-    CKey secret = DecodeSecret(strKeyOrAddress);
-    if (!secret.IsValid()) {
-        throw std::runtime_error(strprintf("Invalid priv-key/address %s", strKeyOrAddress));
+    LOCK2(pwallet->cs_wallet, spk_man.cs_KeyStore);
+
+    EnsureWalletIsUnlocked(pwallet);
+
+    CTxDestination dest = DecodeDestination(strKeyOrAddress);
+    if (allowAddresses && IsValidDestination(dest)) {
+        auto keyId = GetKeyForDestination(spk_man, dest);
+        if (keyId.IsNull())
+            throw JSONRPCError(RPC_TYPE_ERROR, "Address does not refer to a key");
+        CKey key;
+        if (!spk_man.GetKey(keyId, key))
+            throw std::runtime_error(strprintf("non-wallet or invalid address %s", strKeyOrAddress));
+        return key;
     }
-    return secret;
+#else//ENABLE_WALLET
+        throw std::runtime_error("addresses not supported in no-wallet builds");
+#endif//ENABLE_WALLET
+    CKey key = DecodeSecret(strKeyOrAddress);
+    if (!key.IsValid()) {
+        throw std::runtime_error(strprintf("invalid priv-key/address %s", strKeyOrAddress));
+    }
+    return key;
 }
 
-static CKeyID ParsePubKeyIDFromAddress(const CWallet* pwallet, const std::string& strAddress, const std::string& paramName)
+static CKeyID ParsePubKeyIDFromAddress(CWallet* pwallet, const std::string& strAddress, const std::string& paramName)
 {
-    CTxDestination address = DecodeDestination(strAddress);
-    if (!IsValidDestination(address))
+    LegacyScriptPubKeyMan& spk_man = EnsureLegacyScriptPubKeyMan(*pwallet);
+    CTxDestination dest = DecodeDestination(strAddress);
+    if (!IsValidDestination(dest))
         throw JSONRPCError(RPC_INVALID_PARAMETER, strprintf("%s must be a valid P2PKH address, not %s", paramName, strAddress));
 
-    CKeyID keyID = GetKeyForDestination(*pwallet, address);
-    if (keyID.IsNull())
+    auto keyId = GetKeyForDestination(spk_man, dest);
+    if (keyId.IsNull())
         throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, strprintf("%s does not refer to a key", strAddress));
 
-    return keyID;
+    return keyId;
 }
 
 static CBLSPublicKey ParseBLSPubKey(const std::string& hexKey, const std::string& paramName)
@@ -306,110 +322,97 @@ static std::string SignAndSendSpecialTx(const CMutableTransaction& tx)
 void protx_register_fund_help(const CWallet* pwallet)
 {
     throw std::runtime_error(
-        RPCHelpMan{"protx register_fund",
-            "\nCreates, funds and sends a ProTx to the network. The resulting transaction will move 2500 BITG\n"
+            "protx register_fund \"collateralAddress\" \"ipAndPort\" \"ownerAddress\" \"operatorPubKey\" \"votingAddress\" operatorReward \"payoutAddress\" ( \"fundAddress\" )\n"
+            "\nCreates, funds and sends a ProTx to the network. The resulting transaction will move 1000 Dash\n"
             "to the address specified by collateralAddress and will then function as the collateral of your\n"
-            "masternode.\n",
-            {
-                GetHelpArg("collateralAddress"),
-                GetHelpArg("ipAndPort"),
-                GetHelpArg("ownerAddress"),
-                GetHelpArg("operatorPubKey"),
-                GetHelpArg("votingAddress"),
-                GetHelpArg("operatorReward"),
-                GetHelpArg("payoutAddress"),
-                GetHelpArg("fundAddress")
-            },
-            RPCResult{
-                "\"txid\"                        (string) The transaction id.\n"
-            },
-            RPCExamples{
-                HelpExampleCli("protx", "register_fund \"XrVhS9LogauRJGJu2sHuryjhpuex4RNPSb\" \"1.2.3.4:1234\" \"Xt9AMWaYSz7tR7Uo7gzXA3m4QmeWgrR3rr\" \"93746e8731c57f87f79b3620a7982924e2931717d49540a85864bd543de11c43fb868fd63e501a1db37e19ed59ae6db4\" \"Xt9AMWaYSz7tR7Uo7gzXA3m4QmeWgrR3rr\" 0 \"XrVhS9LogauRJGJu2sHuryjhpuex4RNPSb\"")
-            },
-        }.ToString()
+            "masternode.\n"
+            "A few of the limitations you see in the arguments are temporary and might be lifted after DIP3\n"
+            "is fully deployed.\n"
+            + HelpRequiringPassphrase(pwallet) + "\n"
+            "\nArguments:\n"
+            + GetHelpString(1, "collateralAddress")
+            + GetHelpString(2, "ipAndPort")
+            + GetHelpString(3, "ownerAddress")
+            + GetHelpString(4, "operatorPubKey_register")
+            + GetHelpString(5, "votingAddress_register")
+            + GetHelpString(6, "operatorReward")
+            + GetHelpString(7, "payoutAddress_register")
+            + GetHelpString(8, "fundAddress") +
+            "\nResult:\n"
+            "\"txid\"                        (string) The transaction id.\n"
+            "\nExamples:\n"
+            + HelpExampleCli("protx", "register_fund \"XrVhS9LogauRJGJu2sHuryjhpuex4RNPSb\" \"1.2.3.4:1234\" \"Xt9AMWaYSz7tR7Uo7gzXA3m4QmeWgrR3rr\" \"93746e8731c57f87f79b3620a7982924e2931717d49540a85864bd543de11c43fb868fd63e501a1db37e19ed59ae6db4\" \"Xt9AMWaYSz7tR7Uo7gzXA3m4QmeWgrR3rr\" 0 \"XrVhS9LogauRJGJu2sHuryjhpuex4RNPSb\"")
     );
 }
 
 void protx_register_help(CWallet* const pwallet)
 {
     throw std::runtime_error(
-        RPCHelpMan{"protx register",
+            "protx register \"collateralHash\" collateralIndex \"ipAndPort\" \"ownerAddress\" \"operatorPubKey\" \"votingAddress\" operatorReward \"payoutAddress\" ( \"feeSourceAddress\" )\n"
             "\nSame as \"protx register_fund\", but with an externally referenced collateral.\n"
             "The collateral is specified through \"collateralHash\" and \"collateralIndex\" and must be an unspent\n"
             "transaction output spendable by this wallet. It must also not be used by any other masternode.\n"
-            + HelpRequiringPassphrase(pwallet) + "\n",
-            {
-                GetHelpArg("collateralHash"),
-                GetHelpArg("collateralIndex"),
-                GetHelpArg("ipAndPort"),
-                GetHelpArg("ownerAddress"),
-                GetHelpArg("operatorPubKey"),
-                GetHelpArg("votingAddress"),
-                GetHelpArg("operatorReward"),
-                GetHelpArg("payoutAddress"),
-                GetHelpArg("feeSourceAddress")
-            },
-            RPCResult{
+            + HelpRequiringPassphrase(pwallet) + "\n"
+            "\nArguments:\n"
+            + GetHelpString(1, "collateralHash")
+            + GetHelpString(2, "collateralIndex")
+            + GetHelpString(3, "ipAndPort")
+            + GetHelpString(4, "ownerAddress")
+            + GetHelpString(5, "operatorPubKey_register")
+            + GetHelpString(6, "votingAddress_register")
+            + GetHelpString(7, "operatorReward")
+            + GetHelpString(8, "payoutAddress_register")
+            + GetHelpString(9, "feeSourceAddress") +
+            "\nResult:\n"
                 "\"txid\"                        (string) The transaction id.\n"
-            },
-            RPCExamples{
-                HelpExampleCli("protx", "register \"0123456701234567012345670123456701234567012345670123456701234567\" 0 \"1.2.3.4:1234\" \"Xt9AMWaYSz7tR7Uo7gzXA3m4QmeWgrR3rr\" \"93746e8731c57f87f79b3620a7982924e2931717d49540a85864bd543de11c43fb868fd63e501a1db37e19ed59ae6db4\" \"Xt9AMWaYSz7tR7Uo7gzXA3m4QmeWgrR3rr\" 0 \"XrVhS9LogauRJGJu2sHuryjhpuex4RNPSb\"")
-            }
-        }.ToString()
+            "\nExamples:\n"
+            + HelpExampleCli("protx", "register \"0123456701234567012345670123456701234567012345670123456701234567\" 0 \"1.2.3.4:1234\" \"Xt9AMWaYSz7tR7Uo7gzXA3m4QmeWgrR3rr\" \"93746e8731c57f87f79b3620a7982924e2931717d49540a85864bd543de11c43fb868fd63e501a1db37e19ed59ae6db4\" \"Xt9AMWaYSz7tR7Uo7gzXA3m4QmeWgrR3rr\" 0 \"XrVhS9LogauRJGJu2sHuryjhpuex4RNPSb\"")
     );
 }
 
 void protx_register_prepare_help()
 {
     throw std::runtime_error(
-        RPCHelpMan{"protx register_prepare",
+            "protx register_prepare \"collateralHash\" collateralIndex \"ipAndPort\" \"ownerAddress\" \"operatorPubKey\" \"votingAddress\" operatorReward \"payoutAddress\" ( \"feeSourceAddress\" )\n"
             "\nCreates an unsigned ProTx and returns it. The ProTx must be signed externally with the collateral\n"
             "key and then passed to \"protx register_submit\". The prepared transaction will also contain inputs\n"
-            "and outputs to cover fees.\n",
-            {
-                GetHelpArg("collateralHash"),
-                GetHelpArg("collateralIndex"),
-                GetHelpArg("ipAndPort"),
-                GetHelpArg("ownerAddress"),
-                GetHelpArg("operatorPubKey"),
-                GetHelpArg("votingAddress"),
-                GetHelpArg("operatorReward"),
-                GetHelpArg("payoutAddress"),
-                GetHelpArg("feeSourceAddress")
-            },
-            RPCResult{
+            "and outputs to cover fees.\n"
+            "\nArguments:\n"
+            + GetHelpString(1, "collateralHash")
+            + GetHelpString(2, "collateralIndex")
+            + GetHelpString(3, "ipAndPort")
+            + GetHelpString(4, "ownerAddress")
+            + GetHelpString(5, "operatorPubKey_register")
+            + GetHelpString(6, "votingAddress_register")
+            + GetHelpString(7, "operatorReward")
+            + GetHelpString(8, "payoutAddress_register")
+            + GetHelpString(9, "feeSourceAddress") +
+            "\nResult:\n"
                 "{                             (json object)\n"
                 "  \"tx\" :                      (string) The serialized ProTx in hex format.\n"
                 "  \"collateralAddress\" :       (string) The collateral address.\n"
                 "  \"signMessage\" :             (string) The string message that needs to be signed with\n"
                 "                              the collateral key.\n"
                 "}\n"
-            },
-            RPCExamples{
-                HelpExampleCli("protx", "register_prepare \"0123456701234567012345670123456701234567012345670123456701234567\" 0 \"1.2.3.4:1234\" \"Xt9AMWaYSz7tR7Uo7gzXA3m4QmeWgrR3rr\" \"93746e8731c57f87f79b3620a7982924e2931717d49540a85864bd543de11c43fb868fd63e501a1db37e19ed59ae6db4\" \"Xt9AMWaYSz7tR7Uo7gzXA3m4QmeWgrR3rr\" 0 \"XrVhS9LogauRJGJu2sHuryjhpuex4RNPSb\"")
-            }
-        }.ToString()
+            "\nExamples:\n"
+            + HelpExampleCli("protx", "register_prepare \"0123456701234567012345670123456701234567012345670123456701234567\" 0 \"1.2.3.4:1234\" \"Xt9AMWaYSz7tR7Uo7gzXA3m4QmeWgrR3rr\" \"93746e8731c57f87f79b3620a7982924e2931717d49540a85864bd543de11c43fb868fd63e501a1db37e19ed59ae6db4\" \"Xt9AMWaYSz7tR7Uo7gzXA3m4QmeWgrR3rr\" 0 \"XrVhS9LogauRJGJu2sHuryjhpuex4RNPSb\"")
     );
 }
 
 void protx_register_submit_help(CWallet* const pwallet)
 {
     throw std::runtime_error(
-        RPCHelpMan{"protx register_submit",
+            "protx register_submit \"tx\" \"sig\"\n"
             "\nSubmits the specified ProTx to the network. This command will also sign the inputs of the transaction\n"
             "which were previously added by \"protx register_prepare\" to cover transaction fees\n"
-            + HelpRequiringPassphrase(pwallet) + "\n",
-            {
-                RPCArg{"tx", RPCArg::Type::STR, RPCArg::Optional::NO, "The serialized transaction previously returned by \"protx register_prepare\""},
-                RPCArg{"sig", RPCArg::Type::STR, RPCArg::Optional::NO, "The signature signed with the collateral key. Must be in base64 format."}
-            },
-            RPCResult{
+            + HelpRequiringPassphrase(pwallet) + "\n"
+            "\nArguments:\n"
+            "1. \"tx\"                 (string, required) The serialized transaction previously returned by \"protx register_prepare\"\n"
+            "2. \"sig\"                (string, required) The signature signed with the collateral key. Must be in base64 format.\n"
+            "\nResult:\n"
                 "\"txid\"                  (string) The transaction id.\n"
-            },
-            RPCExamples{
-                HelpExampleCli("protx", "register_submit \"tx\" \"sig\"")
-            }
-        }.ToString()
+            "\nExamples:\n"
+            + HelpExampleCli("protx", "register_submit \"tx\" \"sig\"")
     );
 }
 
@@ -418,8 +421,6 @@ UniValue protx_register(const JSONRPCRequest& request)
 {
     std::shared_ptr<CWallet> const wallet = GetWalletForJSONRPCRequest(request);
     CWallet* const pwallet = wallet.get();
-    if (!EnsureWalletIsAvailable(pwallet, request.fHelp))
-        return NullUniValue;
 
     bool isExternalRegister = request.params[0].get_str() == "register";
     bool isFundRegister = request.params[0].get_str() == "register_fund";
@@ -532,18 +533,20 @@ UniValue protx_register(const JSONRPCRequest& request)
         return SignAndSendSpecialTx(tx);
     } else {
         // referencing external collateral
+
         Coin coin;
-        if (!GetUTXOCoin(ptx.collateralOutpoint, coin))
-            throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, strprintf("collateral not found: %s", ptx.collateralOutpoint.ToString()));
-
+        if (!GetUTXOCoin(ptx.collateralOutpoint, coin)) {
+            throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, strprintf("collateral not found: %s", ptx.collateralOutpoint.ToStringShort()));
+        }
         CTxDestination txDest;
+        ExtractDestination(coin.out.scriptPubKey, txDest);
         CKeyID keyID;
-        if (!ExtractDestination(coin.out.scriptPubKey, txDest))
-            throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, strprintf("collateral type not supported: %s", ptx.collateralOutpoint.ToString()));
-
-        keyID = GetKeyForDestination(*pwallet, txDest);
-        if (keyID.IsNull())
-            throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, strprintf("collateral type not supported: %s", ptx.collateralOutpoint.ToString()));
+        if (auto key_id = boost::get<PKHash>(&txDest)) {	
+            keyID = CKeyID(*key_id);
+        }
+        if (keyID.IsNull()) {
+            throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, strprintf("collateral type not supported: %s", ptx.collateralOutpoint.ToStringShort()));
+        }
 
         if (isPrepareRegister) {
             // external signing with collateral key
@@ -560,8 +563,15 @@ UniValue protx_register(const JSONRPCRequest& request)
         } else {
             // lets prove we own the collateral
             CKey key;
-            if (!pwallet->GetKey(keyID, key))
-                throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, strprintf("collateral key not in wallet: %s", EncodeDestination(txDest)));
+            {
+                
+                // lets prove we own the collateral
+                LegacyScriptPubKeyMan& spk_man = EnsureLegacyScriptPubKeyMan(*pwallet);
+                LOCK2(pwallet->cs_wallet, spk_man.cs_KeyStore);
+                if (!spk_man.GetKey(keyID, key)) {
+                    throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, strprintf("collateral key not in wallet: %s", EncodeDestination(txDest)));
+                }
+            }
             SignSpecialTxPayloadByString(tx, ptx, key);
             SetTxPayload(tx, ptx);
             return SignAndSendSpecialTx(tx);
@@ -602,25 +612,21 @@ UniValue protx_register_submit(const JSONRPCRequest& request)
 void protx_update_service_help(CWallet* const pwallet)
 {
     throw std::runtime_error(
-        RPCHelpMan{"protx update_service",
+            "protx update_service \"proTxHash\" \"ipAndPort\" \"operatorKey\" (\"operatorPayoutAddress\" \"feeSourceAddress\" )\n"
             "\nCreates and sends a ProUpServTx to the network. This will update the IP address\n"
             "of a masternode.\n"
             "If this is done for a masternode that got PoSe-banned, the ProUpServTx will also revive this masternode.\n"
-            + HelpRequiringPassphrase(pwallet) + "\n",
-            {
-                GetHelpArg("proTxHash"),
-                GetHelpArg("ipAndPort"),
-                GetHelpArg("operatorKey"),
-                GetHelpArg("operatorPayoutAddress"),
-                GetHelpArg("feeSourceAddress")
-            },
-            RPCResult{
+            + HelpRequiringPassphrase(pwallet) + "\n"
+            "\nArguments:\n"
+            + GetHelpString(1, "proTxHash")
+            + GetHelpString(2, "ipAndPort")
+            + GetHelpString(3, "operatorKey")
+            + GetHelpString(4, "operatorPayoutAddress")
+            + GetHelpString(5, "feeSourceAddress") +
+            "\nResult:\n"
                 "\"txid\"                  (string) The transaction id.\n"
-            },
-            RPCExamples{
-                HelpExampleCli("protx", "update_service \"0123456701234567012345670123456701234567012345670123456701234567\" \"1.2.3.4:1234\" 5a2e15982e62f1e0b7cf9783c64cf7e3af3f90a52d6c40f6f95d624c0b1621cd")
-            }
-        }.ToString()
+            "\nExamples:\n"
+            + HelpExampleCli("protx", "update_service \"0123456701234567012345670123456701234567012345670123456701234567\" \"1.2.3.4:1234\" 5a2e15982e62f1e0b7cf9783c64cf7e3af3f90a52d6c40f6f95d624c0b1621cd")
     );
 }
 
@@ -703,25 +709,21 @@ UniValue protx_update_service(const JSONRPCRequest& request)
 void protx_update_registrar_help(CWallet* const pwallet)
 {
     throw std::runtime_error(
-        RPCHelpMan{"protx update_registrar",
+            "protx update_registrar \"proTxHash\" \"operatorPubKey\" \"votingAddress\" \"payoutAddress\" ( \"feeSourceAddress\" )\n"
             "\nCreates and sends a ProUpRegTx to the network. This will update the operator key, voting key and payout\n"
             "address of the masternode specified by \"proTxHash\".\n"
             "The owner key of the masternode must be known to your wallet.\n"
-            + HelpRequiringPassphrase(pwallet) + "\n",
-            {
-                GetHelpArg("proTxHash"),
-                GetHelpArg("operatorPubKey"),
-                GetHelpArg("votingAddress"),
-                GetHelpArg("payoutAddress"),
-                GetHelpArg("feeSourceAddress")
-            },
-            RPCResult{
+            + HelpRequiringPassphrase(pwallet) + "\n"
+            "\nArguments:\n"
+            + GetHelpString(1, "proTxHash")
+            + GetHelpString(2, "operatorPubKey_update")
+            + GetHelpString(3, "votingAddress_update")
+            + GetHelpString(4, "payoutAddress_update")
+            + GetHelpString(5, "feeSourceAddress") +
+            "\nResult:\n"
                 "\"txid\"                  (string) The transaction id.\n"
-            },
-            RPCExamples{
-                HelpExampleCli("protx", "update_registrar \"0123456701234567012345670123456701234567012345670123456701234567\" \"982eb34b7c7f614f29e5c665bc3605f1beeef85e3395ca12d3be49d2868ecfea5566f11cedfad30c51b2403f2ad95b67\" \"XwnLY9Tf7Zsef8gMGL2fhWA9ZmMjt4KPwG\"")
-            }
-        }.ToString()
+            "\nExamples:\n"
+            + HelpExampleCli("protx", "update_registrar \"0123456701234567012345670123456701234567012345670123456701234567\" \"982eb34b7c7f614f29e5c665bc3605f1beeef85e3395ca12d3be49d2868ecfea5566f11cedfad30c51b2403f2ad95b67\" \"XwnLY9Tf7Zsef8gMGL2fhWA9ZmMjt4KPwG\"")
     );
 }
 
@@ -750,10 +752,12 @@ UniValue protx_update_registrar(const JSONRPCRequest& request)
     // ptx.keyIDVoting = dmn->pdmnState->keyIDVoting;
     // ptx.scriptPayout = dmn->pdmnState->scriptPayout;
 
-    if (request.params[2].get_str() != "")
+    if (request.params[2].get_str() != "") {
         ptx.pubKeyOperator = ParseBLSPubKey(request.params[2].get_str(), "operator BLS address");
-    if (request.params[3].get_str() != "")
+    }
+    if (request.params[3].get_str() != "") {
         ptx.keyIDVoting = ParsePubKeyIDFromAddress(pwallet, request.params[3].get_str(), "voting address");
+    }
 
     CTxDestination payoutAddress = DecodeDestination(request.params[4].get_str());
     if (!IsValidDestination(payoutAddress))
@@ -788,25 +792,21 @@ UniValue protx_update_registrar(const JSONRPCRequest& request)
 void protx_revoke_help(CWallet* const pwallet)
 {
     throw std::runtime_error(
-        RPCHelpMan{"protx revoke",
+            "protx revoke \"proTxHash\" \"operatorKey\" ( reason \"feeSourceAddress\")\n"
             "\nCreates and sends a ProUpRevTx to the network. This will revoke the operator key of the masternode and\n"
             "put it into the PoSe-banned state. It will also set the service field of the masternode\n"
             "to zero. Use this in case your operator key got compromised or you want to stop providing your service\n"
             "to the masternode owner.\n"
-            + HelpRequiringPassphrase(pwallet) + "\n",
-            {
-                GetHelpArg("proTxHash"),
-                GetHelpArg("operatorKey"),
-                GetHelpArg("reason"),
-                GetHelpArg("feeSourceAddress")
-            },
-            RPCResult{
+            + HelpRequiringPassphrase(pwallet) + "\n"
+            "\nArguments:\n"
+            + GetHelpString(1, "proTxHash")
+            + GetHelpString(2, "operatorKey")
+            + GetHelpString(3, "reason")
+            + GetHelpString(4, "feeSourceAddress") +
+            "\nResult:\n"
                 "\"txid\"                  (string) The transaction id.\n"
-            },
-            RPCExamples{
-                HelpExampleCli("protx", "revoke \"0123456701234567012345670123456701234567012345670123456701234567\" \"072f36a77261cdd5d64c32d97bac417540eddca1d5612f416feb07ff75a8e240\"")
-            }
-        }.ToString()
+            "\nExamples:\n"
+            + HelpExampleCli("protx", "revoke \"0123456701234567012345670123456701234567012345670123456701234567\" \"072f36a77261cdd5d64c32d97bac417540eddca1d5612f416feb07ff75a8e240\"")
     );
 }
 
@@ -879,8 +879,11 @@ UniValue protx_revoke(const JSONRPCRequest& request)
 void protx_list_help()
 {
     throw std::runtime_error(
-        RPCHelpMan{"protx list",
+            "protx list (\"type\" \"detailed\" \"height\")\n"
             "\nLists all ProTxs in your wallet or on-chain, depending on the given type.\n"
+            "If \"type\" is not specified, it defaults to \"registered\".\n"
+            "If \"detailed\" is not specified, it defaults to \"false\" and only the hashes of the ProTx will be returned.\n"
+            "If \"height\" is not specified, it defaults to the current chain-tip.\n"
             "\nAvailable types:\n"
             "  registered   - List all ProTx which are registered at the given chain height.\n"
             "                 This will also include ProTx which failed PoSe verfication.\n"
@@ -889,14 +892,6 @@ void protx_list_help()
             "  wallet       - List only ProTx which are found in your wallet at the given chain height.\n"
             "                 This will also include ProTx which failed PoSe verfication.\n"
 #endif
-            ,{
-                {"type", RPCArg::Type::STR, RPCArg::Optional::OMITTED, "If not specified, defaults to \"registered\"."},
-                {"detailed", RPCArg::Type::BOOL, RPCArg::Optional::OMITTED, "If not specified, defaults to \"false\" and only the hashes of the ProTx will be returned."},
-                {"height", RPCArg::Type::NUM, RPCArg::Optional::OMITTED, "If not specified, defaults to the current chain-tip."},
-            },
-            RPCResult{""},
-            RPCExamples{""}
-        }.ToString()
     );
 }
 
@@ -907,7 +902,12 @@ static bool CheckWalletOwnsKey(CWallet* pwallet, const CKeyID& keyID) {
     if (!pwallet) {
         return false;
     }
-    return pwallet->HaveKey(keyID);
+    return true;
+/*
+    LegacyScriptPubKeyMan& spk_man = EnsureLegacyScriptPubKeyMan(*pwallet);
+    LOCK2(pwallet->cs_wallet, spk_man.cs_KeyStore);
+    return spk_man.IsMine(GetScriptForDestination(CTxDestination(keyID)));
+*/
 #endif
 }
 
@@ -920,10 +920,10 @@ static bool CheckWalletOwnsScript(CWallet* pwallet, const CScript& script) {
     }
 
     CTxDestination dest;
+
     if (ExtractDestination(script, dest))
         if (IsMine(*pwallet, dest))
             return true;
-
     return false;
 #endif
 }
@@ -1043,20 +1043,15 @@ UniValue protx_list(const JSONRPCRequest& request)
 void protx_info_help()
 {
     throw std::runtime_error(
-        RPCHelpMan{"protx info",
-            "\nReturns detailed information about a deterministic masternode.\n",
-            {
-                GetHelpArg("proTxHash")
-            },
-            RPCResult{
-                "{\n"
-                "    (json object) Details about a specific deterministic masternode\n"
+            "protx info \"proTxHash\"\n"
+            "\nReturns detailed information about a deterministic masternode.\n"
+            "\nArguments:\n"
+            + GetHelpString(1, "proTxHash") +
+            "\nResult:\n"
+            "{                             (json object) Details about a specific deterministic masternode\n"
                 "}\n"
-            },
-            RPCExamples{
-                HelpExampleCli("protx", "info \"0123456701234567012345670123456701234567012345670123456701234567\"")
-            }
-        }.ToString()
+            "\nExamples:\n"
+            + HelpExampleCli("protx", "info \"0123456701234567012345670123456701234567012345670123456701234567\"")
     );
 }
 
@@ -1084,12 +1079,12 @@ UniValue protx_info(const JSONRPCRequest& request)
 void protx_help()
 {
     throw std::runtime_error(
-        RPCHelpMan{"protx",
-            "\nSet of commands to execute ProTx related actions.\n",
-            {
-                {"command", RPCArg::Type::STR, /* default */ "all commands", "The command to get help on"},
-            },
-            RPCResult{
+            "protx \"command\" ...\n"
+            "Set of commands to execute ProTx related actions.\n"
+            "To get help on individual commands, use \"help protx command\".\n"
+            "\nArguments:\n"
+            "1. \"command\"        (string, required) The command to execute\n"
+            "\nAvailable commands:\n"
 #ifdef ENABLE_WALLET
                 "  register          - Create and send ProTx to network\n"
                 "  register_fund     - Fund, create and send ProTx to network\n"
@@ -1103,9 +1098,7 @@ void protx_help()
                 "  update_registrar  - Create and send ProUpRegTx to network\n"
                 "  revoke            - Create and send ProUpRevTx to network\n"
 #endif
-            },
-            RPCExamples{""},
-        }.ToString()
+            "  diff              - Calculate a diff and a proof between two masternode lists\n"
     );
 }
 
@@ -1144,19 +1137,15 @@ UniValue protx(const JSONRPCRequest& request)
 void bls_generate_help()
 {
     throw std::runtime_error(
-        RPCHelpMan{"bls generate",
-            "\nReturns a BLS secret/public key pair.\n",
-            {},
-            RPCResult{
+            "bls generate\n"
+            "\nReturns a BLS secret/public key pair.\n"
+            "\nResult:\n"
                 "{\n"
                 "  \"secret\": \"xxxx\",        (string) BLS secret key\n"
                 "  \"public\": \"xxxx\",        (string) BLS public key\n"
                 "}\n"
-            },
-            RPCExamples{
-                HelpExampleCli("bls generate", "")
-            },
-        }.ToString()
+            "\nExamples:\n"
+            + HelpExampleCli("bls generate", "")
     );
 }
 
@@ -1177,21 +1166,17 @@ UniValue bls_generate(const JSONRPCRequest& request)
 void bls_fromsecret_help()
 {
     throw std::runtime_error(
-        RPCHelpMan{"bls fromsecret",
-            "\nParses a BLS secret key and returns the secret/public key pair.\n",
-            {
-                {"secret", RPCArg::Type::STR, RPCArg::Optional::NO, "The BLS secret key"},
-            },
-            RPCResult{
+            "bls fromsecret \"secret\"\n"
+            "\nParses a BLS secret key and returns the secret/public key pair.\n"
+            "\nArguments:\n"
+            "1. \"secret\"                (string, required) The BLS secret key\n"
+            "\nResult:\n"
                 "{\n"
                 "  \"secret\": \"xxxx\",        (string) BLS secret key\n"
                 "  \"public\": \"xxxx\",        (string) BLS public key\n"
                 "}\n"
-            },
-            RPCExamples{
-                HelpExampleCli("bls fromsecret", "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f")
-            },
-        }.ToString()
+            "\nExamples:\n"
+            + HelpExampleCli("bls fromsecret", "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f")
     );
 }
 
@@ -1213,18 +1198,14 @@ UniValue bls_fromsecret(const JSONRPCRequest& request)
 void bls_help()
 {
     throw std::runtime_error(
-        RPCHelpMan{"bls",
-            "\nSet of commands to execute BLS related actions.\n"
-            "To get help on individual commands, use \"help bls command\".\n",
-            {
-                {"command", RPCArg::Type::STR, RPCArg::Optional::NO, "The command to execute"},
-            },
-            RPCResult{
+            "bls \"command\" ...\n"
+            "Set of commands to execute BLS related actions.\n"
+            "To get help on individual commands, use \"help bls command\".\n"
+            "\nArguments:\n"
+            "1. \"command\"        (string, required) The command to execute\n"
+            "\nAvailable commands:\n"
                 "  generate          - Create a BLS secret/public key pair\n"
                 "  fromsecret        - Parse a BLS secret key and return the secret/public key pair\n"
-            },
-            RPCExamples{""},
-        }.ToString()
     );
 }
 

--- a/src/special/mnauth.cpp
+++ b/src/special/mnauth.cpp
@@ -117,14 +117,15 @@ void CMNAuth::ProcessMessage(CNode* pnode, const std::string& strCommand, CDataS
     }
 }
 
-void CMNAuth::NotifyMasternodeListChanged(bool undo, const CDeterministicMNList& oldMNList, const CDeterministicMNListDiff& diff)
+void CMNAuth::NotifyMasternodeListChanged(bool undo, const CDeterministicMNList& oldMNList, const CDeterministicMNListDiff& diff, CConnman& connman)
 {
     // we're only interested in updated/removed MNs. Added MNs are of no interest for us
     if (diff.updatedMNs.empty() && diff.removedMns.empty()) {
         return;
     }
 
-    g_connman->ForEachNode([&](CNode* pnode) {
+    connman.ForEachNode([&](CNode* pnode)
+    {
         LOCK(pnode->cs_mnauth);
         if (pnode->verifiedProRegTxHash.IsNull()) {
             return;

--- a/src/special/mnauth.h
+++ b/src/special/mnauth.h
@@ -52,7 +52,7 @@ public:
 
     static void PushMNAUTH(CNode* pnode, CConnman* connman);
     static void ProcessMessage(CNode* pnode, const std::string& strCommand, CDataStream& vRecv, CConnman* connman);
-    static void NotifyMasternodeListChanged(bool undo, const CDeterministicMNList& oldMNList, const CDeterministicMNListDiff& diff);
+    static void NotifyMasternodeListChanged(bool undo, const CDeterministicMNList& oldMNList, const CDeterministicMNListDiff& diff, CConnman& connman);
 };
 
 

--- a/src/special/providertx.h
+++ b/src/special/providertx.h
@@ -9,7 +9,10 @@
 #include <consensus/validation.h>
 #include <primitives/transaction.h>
 
+#include <base58.h>
 #include <netaddress.h>
+#include <script/standard.h>
+#include <key_io.h>
 #include <pubkey.h>
 
 class CBlockIndex;

--- a/src/special/specialtx.cpp
+++ b/src/special/specialtx.cpp
@@ -102,7 +102,8 @@ bool ProcessSpecialTxsInBlock(const CBlock& block, const CBlockIndex* pindex, Tx
     int64_t nTime2 = GetTimeMicros(); nTimeLoop += nTime2 - nTime1;
     LogPrint(BCLog::BENCHMARK, "        - Loop: %.2fms [%.2fs]\n", 0.001 * (nTime2 - nTime1), nTimeLoop * 0.000001);
 
-    if (!llmq::quorumBlockProcessor->ProcessBlock(block, pindex, state))
+    BlockValidationState blk_state;
+    if (!llmq::quorumBlockProcessor->ProcessBlock(block, pindex, blk_state))
         return false;
 
     int64_t nTime3 = GetTimeMicros(); nTimeQuorum += nTime3 - nTime2;

--- a/src/spork.h
+++ b/src/spork.h
@@ -119,7 +119,7 @@ public:
     /**
      * Relay is used to send this spork message to other peers.
      */
-    void Relay();
+    void Relay(CConnman& connman);
 };
 
 /**
@@ -210,7 +210,7 @@ public:
      * UpdateSpork is used by the spork RPC command to set a new spork value, sign
      * and broadcast the spork message.
      */
-    bool UpdateSpork(int nSporkID, int64_t nValue);
+    bool UpdateSpork(int nSporkID, int64_t nValue, CConnman& connman);
 
     /**
      * IsSporkActive returns a bool for time-based sporks, and should be used

--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -22,7 +22,7 @@ static const char DB_COIN = 'C';
 static const char DB_COINS = 'c';
 static const char DB_BLOCK_FILES = 'f';
 static const char DB_BLOCK_INDEX = 'b';
-
+static const char DB_TXINDEX = 't';
 static const char DB_BEST_BLOCK = 'B';
 static const char DB_HEAD_BLOCKS = 'H';
 static const char DB_FLAG = 'F';
@@ -234,6 +234,17 @@ bool CBlockTreeDB::WriteBatchSync(const std::vector<std::pair<int, const CBlockF
     return WriteBatch(batch, true);
 }
 
+bool CBlockTreeDB::ReadTxIndex(const uint256 &txid, CDiskTxPos &pos) {
+    return Read(std::make_pair(DB_TXINDEX, txid), pos);
+}
+
+bool CBlockTreeDB::WriteTxIndex(const std::vector<std::pair<uint256, CDiskTxPos> >&vect) {
+    CDBBatch batch(*this);
+    for (std::vector<std::pair<uint256,CDiskTxPos> >::const_iterator it=vect.begin(); it!=vect.end(); it++)
+        batch.Write(std::make_pair(DB_TXINDEX, it->first), it->second);
+    return WriteBatch(batch);
+}
+
 bool CBlockTreeDB::WriteFlag(const std::string &name, bool fValue) {
     return Write(std::make_pair(DB_FLAG, name), fValue ? '1' : '0');
 }
@@ -254,7 +265,6 @@ bool CBlockTreeDB::LoadBlockIndexGuts(const Consensus::Params& consensusParams, 
 
     // Load m_block_index
     while (pcursor->Valid()) {
-        boost::this_thread::interruption_point();
         if (ShutdownRequested()) return false;
         std::pair<char, uint256> key;
         if (pcursor->GetKey(key) && key.first == DB_BLOCK_INDEX) {

--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -348,7 +348,7 @@ public:
         vout.assign(vAvail.size(), CTxOut());
         for (unsigned int i = 0; i < vAvail.size(); i++) {
             if (vAvail[i])
-                ::Unserialize(s, Using<TxOutCompression>(vout[i]));
+                ::Unserialize(s, CTxOutCompressor(vout[i]));
         }
         // coinbase height
         ::Unserialize(s, VARINT_MODE(nHeight, VarIntMode::NONNEGATIVE_SIGNED));

--- a/src/txdb.h
+++ b/src/txdb.h
@@ -7,6 +7,7 @@
 #define BITCOIN_TXDB_H
 
 #include <coins.h>
+#include <index/txindex.h>
 #include <dbwrapper.h>
 #include <chain.h>
 #include <primitives/block.h>
@@ -19,6 +20,7 @@
 class CBlockIndex;
 class CCoinsViewDBCursor;
 class uint256;
+class CDiskTxPos;
 
 //! -dbcache default (MiB)
 static const int64_t nDefaultDbCache = 450;
@@ -95,6 +97,8 @@ public:
     bool ReadLastBlockFile(int &nFile);
     bool WriteReindexing(bool fReindexing);
     void ReadReindexing(bool &fReindexing);
+    bool ReadTxIndex(const uint256 &txid, CDiskTxPos &pos);
+    bool WriteTxIndex(const std::vector<std::pair<uint256, CDiskTxPos> > &vect);
     bool WriteFlag(const std::string &name, bool fValue);
     bool ReadFlag(const std::string &name, bool &fValue);
     bool LoadBlockIndexGuts(const Consensus::Params& consensusParams, std::function<CBlockIndex*(const uint256&)> insertBlockIndex);

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -999,7 +999,7 @@ bool CCoinsViewMemPool::GetCoin(const COutPoint &outpoint, Coin &coin) const {
     CTransactionRef ptx = mempool.get(outpoint.hash);
     if (ptx) {
         if (outpoint.n < ptx->vout.size()) {
-            coin = Coin(ptx->vout[outpoint.n], MEMPOOL_HEIGHT, false, ptx->IsCoinStake());
+            coin = Coin(ptx->vout[outpoint.n], MEMPOOL_HEIGHT, false, false);
             return true;
         } else {
             return false;

--- a/src/ui_interface.h
+++ b/src/ui_interface.h
@@ -8,6 +8,7 @@
 
 #include <functional>
 #include <memory>
+#include <stdint.h>
 #include <string>
 
 class CBlockIndex;
@@ -17,6 +18,10 @@ namespace signals2 {
 class connection;
 }
 } // namespace boost
+
+namespace interfaces {
+class Wallet;
+} // namespace interfaces
 
 /** General change type (added, updated, removed). */
 enum ChangeType

--- a/src/util/system.cpp
+++ b/src/util/system.cpp
@@ -71,7 +71,7 @@
 // Application startup time (used for uptime calculation)
 const int64_t nStartupTime = GetTime();
 
-const char * const BITGREEN_CONF_FILENAME = "bitgreen.conf";
+const char * const BITCOIN_CONF_FILENAME = "bitgreen.conf";
 
 ArgsManager gArgs;
 

--- a/src/util/threadnames.cpp
+++ b/src/util/threadnames.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2019 The Bitcoin Core developers
+// Copyright (c) 2018 The Bitcoin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -6,6 +6,8 @@
 #include <config/bitcoin-config.h>
 #endif
 
+#include <atomic>
+#include <map>
 #include <thread>
 
 #if (defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__DragonFly__))
@@ -13,6 +15,10 @@
 #include <pthread_np.h>
 #endif
 
+#include <ctpl.h>
+#include <logging.h>
+#include <tinyformat.h>
+#include <util/time.h>
 #include <util/threadnames.h>
 
 #ifdef HAVE_SYS_PRCTL_H
@@ -64,6 +70,7 @@ void util::ThreadSetInternalName(std::string&& name)
 {
     SetInternalName(std::move(name));
 }
+
 
 void RenameThreadPool(ctpl::thread_pool& tp, const char* baseName)
 {

--- a/src/util/threadnames.h
+++ b/src/util/threadnames.h
@@ -1,17 +1,15 @@
-// Copyright (c) 2018-2019 The Bitcoin Core developers
+// Copyright (c) 2018 The Bitcoin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#ifndef BITCOIN_UTIL_THREADNAMES_H
-#define BITCOIN_UTIL_THREADNAMES_H
+#ifndef BITGREEN_UTIL_THREADNAMES_H
+#define BITGREEN_UTIL_THREADNAMES_H
 
 #include <string>
 
 namespace util {
 //! Rename a thread both in terms of an internal (in-memory) name as well
 //! as its system thread name.
-//! @note Do not call this for the main thread, as this will interfere with
-//! UNIX utilities such as top and killall. Use ThreadSetInternalName instead.
 void ThreadRename(std::string&&);
 
 //! Set the internal (in-memory) name of the current thread only.
@@ -27,4 +25,5 @@ namespace ctpl {
     class thread_pool;
 }
 void RenameThreadPool(ctpl::thread_pool& tp, const char* baseName);
-#endif // BITCOIN_UTIL_THREADNAMES_H
+
+#endif // BITGREEN_UTIL_THREADNAMES_H

--- a/src/util/time.cpp
+++ b/src/util/time.cpp
@@ -75,31 +75,16 @@ int64_t GetSystemTimeInSeconds()
     return GetTimeMicros()/1000000;
 }
 
-void MilliSleep(int64_t n)
-{
-
-/**
- * Boost's sleep_for was uninterruptible when backed by nanosleep from 1.50
- * until fixed in 1.52. Use the deprecated sleep method for the broken case.
- * See: https://svn.boost.org/trac/boost/ticket/7238
- */
-#if defined(HAVE_WORKING_BOOST_SLEEP_FOR)
-    boost::this_thread::sleep_for(boost::chrono::milliseconds(n));
-#elif defined(HAVE_WORKING_BOOST_SLEEP)
-    boost::this_thread::sleep(boost::posix_time::milliseconds(n));
-#else
-//should never get here
-#error missing boost sleep implementation
-#endif
-}
 std::string FormatISO8601DateTime(int64_t nTime) {
     struct tm ts;
     time_t time_val = nTime;
-#ifdef _MSC_VER
-    gmtime_s(&ts, &time_val);
+#ifdef HAVE_GMTIME_R
+    if (gmtime_r(&time_val, &ts) == nullptr) {
 #else
-    gmtime_r(&time_val, &ts);
+    if (gmtime_s(&ts, &time_val) != 0) {
 #endif
+        return {};
+    }
     return strprintf("%04i-%02i-%02iT%02i:%02i:%02iZ", ts.tm_year + 1900, ts.tm_mon + 1, ts.tm_mday, ts.tm_hour, ts.tm_min, ts.tm_sec);
 }
 
@@ -129,3 +114,9 @@ int64_t ParseISO8601DateTime(const std::string& str)
         return 0;
     return (ptime - epoch).total_seconds();
 }
+
+void MilliSleep(int64_t n)
+{
+    UninterruptibleSleep(std::chrono::milliseconds{n});
+}
+

--- a/src/util/time.h
+++ b/src/util/time.h
@@ -38,8 +38,6 @@ void SetMockTime(int64_t nMockTimeIn);
 /** For testing */
 int64_t GetMockTime();
 
-void MilliSleep(int64_t n);
-
 /** Return system time (or mocked time, if set) */
 template <typename T>
 T GetTime();
@@ -51,5 +49,6 @@ T GetTime();
 std::string FormatISO8601DateTime(int64_t nTime);
 std::string FormatISO8601Date(int64_t nTime);
 int64_t ParseISO8601DateTime(const std::string& str);
+void MilliSleep(int64_t n);
 
 #endif // BITCOIN_UTIL_TIME_H

--- a/src/validation.h
+++ b/src/validation.h
@@ -111,7 +111,7 @@ static const int64_t DEFAULT_MAX_TIP_AGE = 24 * 60 * 60;
 static const int64_t MAX_FEE_ESTIMATION_TIP_AGE = 3 * 60 * 60;
 
 static const bool DEFAULT_CHECKPOINTS_ENABLED = true;
-static const bool DEFAULT_TXINDEX = false;
+static const bool DEFAULT_TXINDEX = true;
 static const char* const DEFAULT_BLOCKFILTERINDEX = "0";
 static const unsigned int DEFAULT_BANSCORE_THRESHOLD = 100;
 /** Default for -persistmempool */
@@ -372,7 +372,7 @@ bool UndoReadFromDisk(CBlockUndo& blockundo, const CBlockIndex* pindex);
 /** Functions for validating blocks and updating the block tree */
 
 /** Context-independent validity checks */
-bool CheckBlock(const CBlock& block, BlockValidationState& state, const Consensus::Params& consensusParams, bool fCheckPOW = true, bool fCheckMerkleRoot = true);
+bool CheckBlock(const CBlock& block, BlockValidationState& state, const Consensus::Params& consensusParams, bool fCheckPOW = true, bool fCheckMerkleRoot = true, bool fCheckSignature = true);
 
 /** Check a block is completely valid from start to finish (only works on top of our current best block) */
 bool TestBlockValidity(BlockValidationState& state, const CChainParams& chainparams, const CBlock& block, CBlockIndex* pindexPrev, bool fCheckPOW = true, bool fCheckMerkleRoot = true) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
@@ -400,9 +400,6 @@ public:
     ~CVerifyDB();
     bool VerifyDB(const CChainParams& chainparams, CCoinsView *coinsview, int nCheckLevel, int nCheckDepth);
 };
-
-/** Replay blocks that aren't fully applied to the database. */
-bool ReplayBlocks(const CChainParams& params, CCoinsView* view);
 
 CBlockIndex* LookupBlockIndex(const uint256& hash) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
@@ -716,7 +713,7 @@ public:
     void ResetBlockFailureFlags(CBlockIndex* pindex) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
     /** Replay blocks that aren't fully applied to the database. */
-    bool ReplayBlocks(const CChainParams& params, CCoinsView* view);
+    bool ReplayBlocks(const CChainParams& params);
     bool RewindBlockIndex(const CChainParams& params) LOCKS_EXCLUDED(cs_main);
     bool LoadGenesisBlock(const CChainParams& chainparams);
 

--- a/src/validationinterface.cpp
+++ b/src/validationinterface.cpp
@@ -277,3 +277,8 @@ void CMainSignals::NotifyGovernanceVote(const CGovernanceVote &vote) {
 void CMainSignals::NotifyGovernanceObject(const CGovernanceObject &object) {
      m_internals->Iterate([&](CValidationInterface& callbacks) { callbacks.NotifyGovernanceObject(object); });
 }
+
+void CMainSignals::SynchronousUpdatedBlockTip(const CBlockIndex *pindexNew, const CBlockIndex *pindexFork, bool fInitialDownload) {
+     m_internals->Iterate([&](CValidationInterface& callbacks) { callbacks.SynchronousUpdatedBlockTip(pindexNew, pindexFork, fInitialDownload); });
+}
+

--- a/src/validationinterface.cpp
+++ b/src/validationinterface.cpp
@@ -246,32 +246,20 @@ void CMainSignals::NewPoWValidBlock(const CBlockIndex *pindex, const std::shared
     m_internals->Iterate([&](CValidationInterface& callbacks) { callbacks.NewPoWValidBlock(pindex, block); });
 }
 
-void CMainSignals::NotifyHeaderTip(const CBlockIndex * pindex, bool fInitialDownload) {
-    m_internals->Iterate([&](CValidationInterface& callbacks) { callbacks.NotifyHeaderTip(pindex, fInitialDownload); });
-}
-
-void CMainSignals::AcceptedBlockHeader(const CBlockIndex * pindex) {
-    m_internals->Iterate([&](CValidationInterface& callbacks) { callbacks.AcceptedBlockHeader(pindex); });
-}
-
-void CMainSignals::NotifyGovernanceVote(const CGovernanceVote &vote) {
-    m_internals->Iterate([&](CValidationInterface& callbacks) { callbacks.NotifyGovernanceVote(vote); });
-}
-
-void CMainSignals::NotifyGovernanceObject(const CGovernanceObject &object) {
-     m_internals->Iterate([&](CValidationInterface& callbacks) { callbacks.NotifyGovernanceObject(object); });
+void CMainSignals::NotifyChainLock(const CBlockIndex* pindexChainLock) {
+    m_internals->Iterate([&](CValidationInterface& callbacks) { callbacks.NotifyChainLock(pindexChainLock); });
 }
 
 void CMainSignals::NotifyMasternodeListChanged(bool undo, const CDeterministicMNList& oldMNList, const CDeterministicMNListDiff& diff) {
      m_internals->Iterate([&](CValidationInterface& callbacks) { callbacks.NotifyMasternodeListChanged(undo, oldMNList, diff); });
 }
 
-void CMainSignals::NotifyChainLock(const CBlockIndex* pindexChainLock) {
-    m_internals->Iterate([&](CValidationInterface& callbacks) { callbacks.NotifyChainLock(pindexChainLock); });
-}
-
 void CMainSignals::SyncTransaction(const CTransaction &tx, const CBlockIndex *pindex, int posInBlock) {
     m_internals->Iterate([&](CValidationInterface& callbacks) { callbacks.SyncTransaction(tx, pindex, posInBlock); });
+}
+
+void CMainSignals::AcceptedBlockHeader(const CBlockIndex * pindexNew) {
+    m_internals->Iterate([&](CValidationInterface& callbacks) { callbacks.AcceptedBlockHeader(pindexNew); });
 }
 
 void CMainSignals::NotifyTransactionLock(const CTransaction &tx) {
@@ -280,4 +268,12 @@ void CMainSignals::NotifyTransactionLock(const CTransaction &tx) {
 
 void CMainSignals::NotifyInstantSendDoubleSpendAttempt(const CTransaction &currentTx, const CTransaction &previousTx) {
     m_internals->Iterate([&](CValidationInterface& callbacks) { callbacks.NotifyInstantSendDoubleSpendAttempt(currentTx, previousTx); });
+}
+
+void CMainSignals::NotifyGovernanceVote(const CGovernanceVote &vote) {
+    m_internals->Iterate([&](CValidationInterface& callbacks) { callbacks.NotifyGovernanceVote(vote); });
+}
+
+void CMainSignals::NotifyGovernanceObject(const CGovernanceObject &object) {
+     m_internals->Iterate([&](CValidationInterface& callbacks) { callbacks.NotifyGovernanceObject(object); });
 }

--- a/src/validationinterface.h
+++ b/src/validationinterface.h
@@ -96,6 +96,10 @@ protected:
      */
     virtual void UpdatedBlockTip(const CBlockIndex *pindexNew, const CBlockIndex *pindexFork, bool fInitialDownload) {}
     /**
+     * Same as UpdatedBlockTip, but called from the caller's thread
+     */
+    virtual void SynchronousUpdatedBlockTip(const CBlockIndex *pindexNew, const CBlockIndex *pindexFork, bool fInitialDownload) {}
+    /**
      * Notifies listeners of a transaction having been added to mempool.
      *
      * Called on a background thread.
@@ -228,6 +232,7 @@ public:
     void TransactionAddedToMempool(const CTransactionRef &);
     void TransactionRemovedFromMempool(const CTransactionRef &);
     void UpdatedBlockTip(const CBlockIndex *, const CBlockIndex *, bool);
+    void SynchronousUpdatedBlockTip(const CBlockIndex *, const CBlockIndex *, bool fInitialDownload);
 };
 
 CMainSignals& GetMainSignals();

--- a/src/wallet/ismine.cpp
+++ b/src/wallet/ismine.cpp
@@ -1,0 +1,193 @@
+// Copyright (c) 2009-2010 Satoshi Nakamoto
+// Copyright (c) 2009-2018 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <wallet/ismine.h>
+
+#include <key.h>
+#include <script/script.h>
+#include <script/sign.h>
+#include <script/signingprovider.h>
+#include <wallet/wallet.h>
+
+typedef std::vector<unsigned char> valtype;
+
+namespace {
+
+/**
+ * This is an enum that tracks the execution context of a script, similar to
+ * SigVersion in script/interpreter. It is separate however because we want to
+ * distinguish between top-level scriptPubKey execution and P2SH redeemScript
+ * execution (a distinction that has no impact on consensus rules).
+ */
+enum class IsMineSigVersion
+{
+    TOP = 0,        //!< scriptPubKey execution
+    P2SH = 1,       //!< P2SH redeemScript
+    WITNESS_V0 = 2, //!< P2WSH witness script execution
+};
+
+/**
+ * This is an internal representation of isminetype + invalidity.
+ * Its order is significant, as we return the max of all explored
+ * possibilities.
+ */
+enum class IsMineResult
+{
+    NO = 0,         //!< Not ours
+    WATCH_ONLY = 1, //!< Included in watch-only balance
+    SPENDABLE = 2,  //!< Included in all balances
+    INVALID = 3,    //!< Not spendable by anyone (uncompressed pubkey in segwit, P2SH inside P2SH or witness, witness inside witness)
+};
+
+bool PermitsUncompressed(IsMineSigVersion sigversion)
+{
+    return sigversion == IsMineSigVersion::TOP || sigversion == IsMineSigVersion::P2SH;
+}
+
+bool HaveKeys(const std::vector<valtype>& pubkeys, const CWallet& keystore)
+{
+    for (const valtype& pubkey : pubkeys) {
+        CKeyID keyID = CPubKey(pubkey).GetID();
+        if (!keystore.HaveKey(keyID)) return false;
+    }
+    return true;
+}
+
+IsMineResult IsMineInner(const CWallet& keystore, const CScript& scriptPubKey, IsMineSigVersion sigversion)
+{
+    IsMineResult ret = IsMineResult::NO;
+
+    std::vector<valtype> vSolutions;
+    txnouttype whichType = Solver(scriptPubKey, vSolutions);
+
+    CKeyID keyID;
+    switch (whichType)
+    {
+    case TX_NONSTANDARD:
+    case TX_NULL_DATA:
+    case TX_WITNESS_UNKNOWN:
+        break;
+    case TX_PUBKEY:
+        keyID = CPubKey(vSolutions[0]).GetID();
+        if (!PermitsUncompressed(sigversion) && vSolutions[0].size() != 33) {
+            return IsMineResult::INVALID;
+        }
+        if (keystore.HaveKey(keyID)) {
+            ret = std::max(ret, IsMineResult::SPENDABLE);
+        }
+        break;
+    case TX_WITNESS_V0_KEYHASH:
+    {
+        if (sigversion == IsMineSigVersion::WITNESS_V0) {
+            // P2WPKH inside P2WSH is invalid.
+            return IsMineResult::INVALID;
+        }
+        if (sigversion == IsMineSigVersion::TOP && !keystore.HaveCScript(CScriptID(CScript() << OP_0 << vSolutions[0]))) {
+            // We do not support bare witness outputs unless the P2SH version of it would be
+            // acceptable as well. This protects against matching before segwit activates.
+            // This also applies to the P2WSH case.
+            break;
+        }
+        ret = std::max(ret, IsMineInner(keystore, GetScriptForDestination(PKHash(uint160(vSolutions[0]))), IsMineSigVersion::WITNESS_V0));
+        break;
+    }
+    case TX_PUBKEYHASH:
+        keyID = CKeyID(uint160(vSolutions[0]));
+        if (!PermitsUncompressed(sigversion)) {
+            CPubKey pubkey;
+            if (keystore.GetPubKey(keyID, pubkey) && !pubkey.IsCompressed()) {
+                return IsMineResult::INVALID;
+            }
+        }
+        if (keystore.HaveKey(keyID)) {
+            ret = std::max(ret, IsMineResult::SPENDABLE);
+        }
+        break;
+    case TX_SCRIPTHASH:
+    {
+        if (sigversion != IsMineSigVersion::TOP) {
+            // P2SH inside P2WSH or P2SH is invalid.
+            return IsMineResult::INVALID;
+        }
+        CScriptID scriptID = CScriptID(uint160(vSolutions[0]));
+        CScript subscript;
+        if (keystore.GetCScript(scriptID, subscript)) {
+            ret = std::max(ret, IsMineInner(keystore, subscript, IsMineSigVersion::P2SH));
+        }
+        break;
+    }
+    case TX_WITNESS_V0_SCRIPTHASH:
+    {
+        if (sigversion == IsMineSigVersion::WITNESS_V0) {
+            // P2WSH inside P2WSH is invalid.
+            return IsMineResult::INVALID;
+        }
+        if (sigversion == IsMineSigVersion::TOP && !keystore.HaveCScript(CScriptID(CScript() << OP_0 << vSolutions[0]))) {
+            break;
+        }
+        uint160 hash;
+        CRIPEMD160().Write(&vSolutions[0][0], vSolutions[0].size()).Finalize(hash.begin());
+        CScriptID scriptID = CScriptID(hash);
+        CScript subscript;
+        if (keystore.GetCScript(scriptID, subscript)) {
+            ret = std::max(ret, IsMineInner(keystore, subscript, IsMineSigVersion::WITNESS_V0));
+        }
+        break;
+    }
+
+    case TX_MULTISIG:
+    {
+        // Never treat bare multisig outputs as ours (they can still be made watchonly-though)
+        if (sigversion == IsMineSigVersion::TOP) {
+            break;
+        }
+
+        // Only consider transactions "mine" if we own ALL the
+        // keys involved. Multi-signature transactions that are
+        // partially owned (somebody else has a key that can spend
+        // them) enable spend-out-from-under-you attacks, especially
+        // in shared-wallet situations.
+        std::vector<valtype> keys(vSolutions.begin()+1, vSolutions.begin()+vSolutions.size()-1);
+        if (!PermitsUncompressed(sigversion)) {
+            for (size_t i = 0; i < keys.size(); i++) {
+                if (keys[i].size() != 33) {
+                    return IsMineResult::INVALID;
+                }
+            }
+        }
+        if (HaveKeys(keys, keystore)) {
+            ret = std::max(ret, IsMineResult::SPENDABLE);
+        }
+        break;
+    }
+    }
+
+    if (ret == IsMineResult::NO && keystore.HaveWatchOnly(scriptPubKey)) {
+        ret = std::max(ret, IsMineResult::WATCH_ONLY);
+    }
+    return ret;
+}
+
+} // namespace
+
+isminetype IsMine(const CWallet& keystore, const CScript& scriptPubKey)
+{
+    switch (IsMineInner(keystore, scriptPubKey, IsMineSigVersion::TOP)) {
+    case IsMineResult::INVALID:
+    case IsMineResult::NO:
+        return ISMINE_NO;
+    case IsMineResult::WATCH_ONLY:
+        return ISMINE_WATCH_ONLY;
+    case IsMineResult::SPENDABLE:
+        return ISMINE_SPENDABLE;
+    }
+    assert(false);
+}
+
+isminetype IsMine(const CWallet& keystore, const CTxDestination& dest)
+{
+    CScript script = GetScriptForDestination(dest);
+    return IsMine(keystore, script);
+}

--- a/src/wallet/ismine.h
+++ b/src/wallet/ismine.h
@@ -28,6 +28,9 @@ enum isminetype : unsigned int
 /** used for bitflags of isminetype */
 typedef uint8_t isminefilter;
 
+isminetype IsMine(const CWallet& wallet, const CScript& scriptPubKey);
+isminetype IsMine(const CWallet& wallet, const CTxDestination& dest);
+
 /**
  * Cachable amount subdivided into watchonly and spendable parts.
  */

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -99,6 +99,13 @@ std::shared_ptr<CWallet> GetWalletForJSONRPCRequest(const JSONRPCRequest& reques
     return wallets.size() == 1 || (request.fHelp && wallets.size() > 0) ? wallets[0] : nullptr;
 }
 
+std::string HelpRequiringPassphrase(const CWallet* pwallet)
+{
+    return pwallet && pwallet->IsCrypted()
+        ? "\nRequires wallet passphrase to be set with walletpassphrase call."
+        : "";
+}
+
 bool EnsureWalletIsAvailable(const CWallet* pwallet, bool avoidException)
 {
     if (pwallet) return true;

--- a/src/wallet/rpcwallet.h
+++ b/src/wallet/rpcwallet.h
@@ -38,6 +38,7 @@ void RegisterWalletRPCCommands(interfaces::Chain& chain, std::vector<std::unique
  */
 std::shared_ptr<CWallet> GetWalletForJSONRPCRequest(const JSONRPCRequest& request);
 
+std::string HelpRequiringPassphrase(const CWallet*);
 void EnsureWalletIsUnlocked(const CWallet*);
 bool EnsureWalletIsAvailable(const CWallet*, bool avoidException);
 LegacyScriptPubKeyMan& EnsureLegacyScriptPubKeyMan(CWallet& wallet, bool also_create = false);


### PR DESCRIPTION
 Missed includes/signals, routine shuffles, move all scheduler tasks onto the node context (bitcoin 0.20 specific), change to using legacy base58 calls via LegacyPubMan. 

Adapt masternode/governance code to work with Bitcoin's new networking setup; pipe connman directly where possible - do not use g_connman, use g_rpc_node where absolutely required. Reimplement some legacy staking code/classes, remove prune code as it isnt suitable for a masternode/pos setup.